### PR TITLE
Expose native b64 decode and encode to the csharp wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ bin
 obj
 .vs
 *.nupkg
+wrappers/csharp/nuget/dotnet/package/*
+wrappers/csharp/nuget/Android/package/*
+wrappers/csharp/nuget/iOS/package/*
+wrappers/csharp/nuget/macOS/package/*

--- a/devolutionscrypto/Cargo.toml
+++ b/devolutionscrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devolutionscrypto"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Philippe Dugre <pdugre@devolutions.net>", "Mathieu Morrissette <mmorrissette@devolutions.net>"]
 edition = "2018"
 readme = "../README.md"
@@ -25,6 +25,7 @@ x25519-dalek = "0.5.2"
 subtle = "2.1.1"
 zeroize = "0.10.1"
 zeroize_derive = "0.10.0"
+base64 = "0.10.1"
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 rand = { version = "0.6.4", features = ["wasm-bindgen"] }

--- a/devolutionscrypto/src/ffi.rs
+++ b/devolutionscrypto/src/ffi.rs
@@ -17,7 +17,7 @@ use std::slice;
 
 use zeroize::Zeroize as _;
 
-use base64::{decode_config_slice, encode_config_slice, Config, CharacterSet};
+use base64::{decode_config_slice, encode_config_slice, STANDARD};
 
 /// Encrypt a data blob
 /// # Arguments
@@ -420,10 +420,9 @@ pub unsafe extern "C" fn Decode(input: *const u8, input_length: usize, output: *
     };
 
     let input = std::str::from_utf8_unchecked(slice::from_raw_parts(input, input_length));
-
     let mut output = slice::from_raw_parts_mut(output, output_length);
 
-    match decode_config_slice(&input, Config::new(CharacterSet::Standard, true), &mut output) {
+    match decode_config_slice(&input, STANDARD, &mut output) {
         Ok(res) => {
             res as i64
         },
@@ -449,10 +448,9 @@ pub unsafe extern "C" fn Encode(input: *const u8, input_length: usize, output: *
     };
 
     let input = slice::from_raw_parts(input, input_length);
-
     let mut output = slice::from_raw_parts_mut(output, output_length);
 
-    encode_config_slice(&input, Config::new(CharacterSet::Standard, true), &mut output) as i64
+    encode_config_slice(&input, STANDARD, &mut output) as i64
 }
 
 #[test]

--- a/devolutionscrypto/src/ffi.rs
+++ b/devolutionscrypto/src/ffi.rs
@@ -17,6 +17,7 @@ use std::slice;
 
 use zeroize::Zeroize as _;
 
+use base64::{decode_config_slice, encode_config_slice, Config, CharacterSet};
 
 /// Encrypt a data blob
 /// # Arguments
@@ -404,6 +405,55 @@ pub extern "C" fn KeySize() -> u32 {
     256
 }
 
+/// Decode a base64 string to bytes.
+/// # Arguments
+///  * input - Pointer to the string to decode.
+///  * input_length - Length of the string to decode.
+///  * output - Pointer to the output buffer.
+///  * output_length - Length of the output buffer.
+/// # Returns
+/// Returns the size of the decoded string.
+#[no_mangle]
+pub unsafe extern "C" fn Decode(input: *const u8, input_length: usize, output: *mut u8 , output_length: usize ) -> i64 {
+    if input.is_null() || output.is_null() {
+        return DevoCryptoError::NullPointer.error_code();
+    };
+
+    let input = std::str::from_utf8_unchecked(slice::from_raw_parts(input, input_length));
+
+    let mut output = slice::from_raw_parts_mut(output, output_length);
+
+    match decode_config_slice(&input, Config::new(CharacterSet::Standard, true), &mut output) {
+        Ok(res) => {
+            res as i64
+        },
+        Err(_e) =>
+        {
+            -1
+        }
+    }
+}
+
+/// Encode a byte array to a base64 string.
+/// # Arguments
+///  * input - Pointer to the buffer to encode.
+///  * input_length - Length of the buffer to encode.
+///  * output - Pointer to the output buffer.
+///  * output_length - Length of the output buffer.
+/// # Returns
+/// Returns the size, in bytes, of the output buffer.
+#[no_mangle]
+pub unsafe extern "C" fn Encode(input: *const u8, input_length: usize, output: *mut u8 , output_length: usize ) -> i64 {
+    if input.is_null() || output.is_null() {
+        return DevoCryptoError::NullPointer.error_code();
+    };
+
+    let input = slice::from_raw_parts(input, input_length);
+
+    let mut output = slice::from_raw_parts_mut(output, output_length);
+
+    encode_config_slice(&input, Config::new(CharacterSet::Standard, true), &mut output) as i64
+}
 
 #[test]
 fn test_encrypt_length() {

--- a/wrappers/csharp/Native.Xamarin.cs
+++ b/wrappers/csharp/Native.Xamarin.cs
@@ -12,11 +12,17 @@ namespace Devolutions.Cryptography
         private const string LibName = "DevolutionsCrypto";
 #endif
 
+        [DllImport(LibName, EntryPoint = "Decode")]
+        public static extern long DecodeNative(byte[] input, UIntPtr input_length, byte[] output, IntPtr output_length);
+
         [DllImport(LibName, EntryPoint = "Decrypt", CallingConvention = CallingConvention.Cdecl)]
         private static extern long DecryptNative(byte[] data, UIntPtr dataLength, byte[] key, UIntPtr keyLength, byte[] result, UIntPtr resultLength);
 
         [DllImport(LibName, EntryPoint = "DeriveKey", CallingConvention = CallingConvention.Cdecl)]
         private static extern long DeriveKeyNative(byte[] key, UIntPtr keyLength, byte[] salt, UIntPtr saltLength, UIntPtr iterations, byte[] result, UIntPtr resultLength);
+
+        [DllImport(LibName, EntryPoint = "Encode")]
+        public static extern long EncodeNative(byte[] input, UIntPtr input_length, byte[] output, UIntPtr output_length);
 
         [DllImport(LibName, EntryPoint = "Encrypt", CallingConvention = CallingConvention.Cdecl)]
         private static extern long EncryptNative(byte[] data, UIntPtr dataLength, byte[] key, UIntPtr keyLength, byte[] result, UIntPtr resultLength);

--- a/wrappers/csharp/Native.cs
+++ b/wrappers/csharp/Native.cs
@@ -382,7 +382,6 @@ namespace Devolutions.Cryptography
         }
 
 #if !ANDROID && !IOS && !MAC
-
         private static long DecryptNative(byte[] data, UIntPtr dataLength, byte[] key, UIntPtr keyLength, byte[] result, UIntPtr resultLength)
         {
             if(Environment.Is64BitProcess)
@@ -443,7 +442,6 @@ namespace Devolutions.Cryptography
             return EncryptSizeNative86(dataLength);
         }
 
-
         [DllImport(LibName86, EntryPoint = "EncryptSize", CallingConvention = CallingConvention.Cdecl)]
         private static extern long EncryptSizeNative86(UIntPtr dataLength);
 
@@ -463,7 +461,6 @@ namespace Devolutions.Cryptography
 
         [DllImport(LibName86, EntryPoint = "GenerateKeyExchange", CallingConvention = CallingConvention.Cdecl)]
         private static extern long GenerateKeyExchangeNative86(byte[] privateKey, UIntPtr privateKeySize, byte[] publicKey, UIntPtr publicKeySize);
-
 
         [DllImport(LibName64, EntryPoint = "GenerateKeyExchange", CallingConvention = CallingConvention.Cdecl)]
         private static extern long GenerateKeyExchangeNative64(byte[] privateKey, UIntPtr privateKeySize, byte[] publicKey, UIntPtr publicKeySize);
@@ -593,12 +590,43 @@ namespace Devolutions.Cryptography
             return VerifyPasswordNative86(password, passwordLength, hash, hashLength);
         }
 
-
         [DllImport(LibName86, EntryPoint = "VerifyPassword", CallingConvention = CallingConvention.Cdecl)]
         private static extern long VerifyPasswordNative86(byte[] password, UIntPtr passwordLength, byte[] hash, UIntPtr hashLength);
 
         [DllImport(LibName64, EntryPoint = "VerifyPassword", CallingConvention = CallingConvention.Cdecl)]
         private static extern long VerifyPasswordNative64(byte[] password, UIntPtr passwordLength, byte[] hash, UIntPtr hashLength);
+
+        public static long DecodeNative(string input, UIntPtr input_length, byte[] output, UIntPtr output_length)
+        {
+            if(Environment.Is64BitProcess)
+            {
+                return Decode64(input, input_length, output, output_length);
+            }
+
+            return Decode86(input, input_length, output, output_length);
+        }
+
+        [DllImport(LibName86, EntryPoint = "Decode")]
+        public static extern long Decode86(string input, UIntPtr input_length, byte[] output, UIntPtr output_length);
+
+        [DllImport(LibName64, EntryPoint = "Decode")]
+        public static extern long Decode64(string input, UIntPtr input_length, byte[] output, UIntPtr output_length);
+
+        public static long EncodeNative(byte[] input, UIntPtr input_length, byte[] output, UIntPtr output_length)
+        {
+            if(Environment.Is64BitProcess)
+            {
+                return Encode64(input, input_length, output, output_length);
+            }
+
+            return Encode86(input, input_length, output, output_length);
+        }
+
+        [DllImport(LibName86, EntryPoint = "Encode")]
+        public static extern long Encode86(byte[] input, UIntPtr input_length, byte[] output, UIntPtr output_length);
+
+        [DllImport(LibName64, EntryPoint = "Encode")]
+        public static extern long Encode64(byte[] input, UIntPtr input_length, byte[] output, UIntPtr output_length);
 #endif
 
 #if RDM

--- a/wrappers/csharp/Utils.cs
+++ b/wrappers/csharp/Utils.cs
@@ -2,7 +2,8 @@ namespace Devolutions.Cryptography
 {
     using System;
     using System.Text;
-    internal static partial class Utils
+    
+    public static partial class Utils
     {
         public static byte[] StringToByteArray(string data)
         {
@@ -21,7 +22,7 @@ namespace Devolutions.Cryptography
                 return null;
             }
 
-            return Convert.ToBase64String(bytes);
+            return Encode(bytes);
         }
 
         public static byte[] Base64StringToByteArray(string data)
@@ -31,14 +32,7 @@ namespace Devolutions.Cryptography
                 return null;
             }
 
-            try
-            {
-                return Convert.FromBase64String(data);
-            }
-            catch
-            {
-                return null;
-            }
+            return Decode(data);
         }
 
         public static string ByteArrayToString(byte[] data)
@@ -56,6 +50,86 @@ namespace Devolutions.Cryptography
             {
                 return null;
             }
+        }
+
+        public static byte[] Decode(string data)
+        {
+            if (data == null || data.Length == 0)
+            {
+                return null;
+            }
+
+            int length = GetDecodedLength(data);
+
+            if(length == 0)
+            {
+                return null;
+            }
+
+            byte[] buffer = new byte[length];
+
+            long decode_res = Native.DecodeNative(data, (UIntPtr)data.Length, buffer, (UIntPtr)buffer.Length);
+
+            if (decode_res == -1)
+                return null;
+            
+            return buffer;
+        }
+
+        public static string Encode(byte[] data)
+        {
+            if (data == null || data.Length == 0)
+            {
+                return null;
+            }
+
+            int length = GetEncodedLength(data);
+
+            if(length == 0)
+            {
+                return null;
+            }
+            
+            byte[] buffer = new byte[length];
+
+            long encode_res = Native.EncodeNative(data, (UIntPtr)data.Length, buffer, (UIntPtr)buffer.Length);
+
+            return ByteArrayToString(buffer);
+        }
+
+        public static int GetEncodedLength(byte[] buffer)
+        {
+            if(buffer == null)
+            {
+                return 0;
+            }
+
+            return ((4 * buffer.Length / 3) + 3) & ~3;
+        }
+
+        public static int GetDecodedLength(string base64)
+        {
+            if (string.IsNullOrEmpty(base64)) 
+            { 
+                return 0; 
+            }
+
+            int characterCount = base64.Length;
+
+            int result = Convert.ToInt32(3 * ((double)characterCount/4));
+		
+            int index = characterCount - 1;
+
+            int loopCount = 1;
+
+            while(base64[index] == '=' && loopCount <= 2)
+            {
+                result--;
+                index--;
+                loopCount++;
+            }
+
+            return  result;
         }
     }
 }


### PR DESCRIPTION
For performance reasons we had to use rust base64 crate to decode as it was many times faster than the .Net implementation.