### PR TITLE
Encrypt/Decrypt v2: XChaCha20Poly1305

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Uses PBKDF2 with HMAC-SHA256 to create a key using the supplied parameters.
 1. Derives the secret into a key using SHA256.  
 2. Generate a random 192bits nonce.  
 3. Encrypt the data using the encryption key and the nonce with the XChaCha20Poly1305 AEAD.  
-5. Final: 4 version bytes + 24 IV bytes + data + 16 authentication tag bytes.
+5. Final: 4 version bytes + 24 nonce bytes + data + 16 authentication tag bytes.
 
 #### HashPassword
 1. Generate a random 256bits salt.  

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ It contains the following functions:
 
 `GenerateKey`: Generate a key of the required size using secure PRNGs.  
 `DeriveKey`: Generates a key from a secret using the supplied parameters.  
-`Encrypt`: Encrypt data with the provided key. Can take any size of key.  
-`Decrypt`: Decrypt data with the provided key. Can take any size of key.  
+`Encrypt`: Encrypt data with the provided key. Can take any size of key, but if it is a password you should use DeriveKey before.  
+`Decrypt`: Decrypt data with the provided key. Can take any size of key, but if it is a password you should use DeriveKey before.  
 `HashPassword`: Hash a password using high-cost algorithm so it is hard to brute-force. Depending on the wrapper,
 you may need to specify an iteration number(the standard is 1000). Can also be used to derive a key. 
 Should be used whenever there is a user provided password.  
@@ -31,16 +31,14 @@ Uses rand::OsRng which uses a platform-dependant cryptographically safe PRNG.
 Uses PBKDF2 with HMAC-SHA256 to create a key using the supplied parameters.
 
 #### Encrypt
-1. Derives the secret using PBKDF2 into two keys using HMAC-SHA256 and 1 iteration: 
-The encryption key(`salt="\x00"`) and the signature key(`salt="\x01"`).  
-2. Generate a random 128bits Initialization Vector(IV).  
-3. Encrypt the data using the encryption key and the IV.  
-4. Create an HMAC-SHA256 of version + IV + encrypted_data using the signature key.  
-5. Final: 4 version bytes + 16 IV bytes + data + 32 HMAC bytes.
+1. Derives the secret into a key using SHA256.  
+2. Generate a random 192bits nonce.  
+3. Encrypt the data using the encryption key and the nonce with the XChaCha20Poly1305 AEAD.  
+5. Final: 4 version bytes + 24 IV bytes + data + 16 authentication tag.
 
 #### HashPassword
 1. Generate a random 256bits salt.  
-2. Hash the password with the salt and the specified iteration number using HMAC-SHA256.  
+2. Hash the password with the salt and the specified iteration number using PBKDF2-HMAC-SHA256.  
 3. Final: 4 version bytes + 4 bytes iterations* + 32 bytes salt + 32 bytes hash
 
 #### KeyExchange

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ It contains the following functions:
 `Encrypt`: Encrypt data with the provided key. Can take any size of key, but if it is a password you should use DeriveKey before.  
 `Decrypt`: Decrypt data with the provided key. Can take any size of key, but if it is a password you should use DeriveKey before.  
 `HashPassword`: Hash a password using high-cost algorithm so it is hard to brute-force. Depending on the wrapper,
-you may need to specify an iteration number(the standard is 1000). Can also be used to derive a key. 
+you may need to specify an iteration number(the standard is 10000). Can also be used to derive a key. 
 Should be used whenever there is a user provided password.  
 `VerifyPassword`: Verify a password hash using constant time equality to prevent an array of side-channels attacks.  
 `GenerateKeyExchange`: Generate a key pair to use in a Key Exchange. Should be used for any data in transit.  
-MixKeyExchange: Mix a public key with a private key. Generates a shared secret between the client and the server.
+`MixKeyExchange`: Mix a public key with a private key. Generates a shared secret between the client and the server.
 
 ### Technical Informations
 As of the current version:
@@ -34,7 +34,7 @@ Uses PBKDF2 with HMAC-SHA256 to create a key using the supplied parameters.
 1. Derives the secret into a key using SHA256.  
 2. Generate a random 192bits nonce.  
 3. Encrypt the data using the encryption key and the nonce with the XChaCha20Poly1305 AEAD.  
-5. Final: 4 version bytes + 24 IV bytes + data + 16 authentication tag.
+5. Final: 4 version bytes + 24 IV bytes + data + 16 authentication tag bytes.
 
 #### HashPassword
 1. Generate a random 256bits salt.  

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ Uses PBKDF2 with HMAC-SHA256 to create a key using the supplied parameters.
 #### Encrypt
 1. Derives the secret into a key using SHA256.  
 2. Generate a random 192bits nonce.  
-3. Encrypt the data using the encryption key and the nonce with the XChaCha20Poly1305 AEAD.  
-5. Final: 4 version bytes + 24 nonce bytes + data + 16 authentication tag bytes.
+3. Encrypt the data using the encryption key and the nonce with the XChaCha20Poly1305 AEAD. The header is used as the associated data so it is authenticated and can't be tampered.  
+5. Final: 8 header bytes + 24 nonce bytes + data + 16 authentication tag bytes.
 
 #### HashPassword
 1. Generate a random 256bits salt.  
 2. Hash the password with the salt and the specified iteration number using PBKDF2-HMAC-SHA256.  
-3. Final: 4 version bytes + 4 bytes iterations* + 32 bytes salt + 32 bytes hash
+3. Final: 8 header bytes + 4 bytes iterations + 32 bytes salt + 32 bytes hash
 
 #### KeyExchange
 The key exchanges uses x25519 protocol, which uses Diffie-Hellman based on elliptic curves.

--- a/devolutionscrypto/Cargo.toml
+++ b/devolutionscrypto/Cargo.toml
@@ -26,6 +26,8 @@ subtle = "2.1.1"
 zeroize = "0.10.1"
 zeroize_derive = "0.10.0"
 base64 = "0.10.1"
+chacha20poly1305 = "0.2.1"
+aead = "0.1.1"
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 rand = { version = "0.6.4", features = ["wasm-bindgen"] }

--- a/devolutionscrypto/Cargo.toml
+++ b/devolutionscrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devolutionscrypto"
-version = "0.1.7"
+version = "0.2.0"
 authors = ["Philippe Dugre <pdugre@devolutions.net>", "Mathieu Morrissette <mmorrissette@devolutions.net>"]
 edition = "2018"
 readme = "../README.md"
@@ -17,15 +17,15 @@ crate-type = ["cdylib", "rlib"]
 aes = "0.3.2"
 block-modes = "0.3.3"
 byteorder="1.3.2"
-cfg-if = "0.1.9"
+cfg-if = "0.1.10"
 hmac = "0.7.1"
-pbkdf2 = { version = "0.3", default-features = false }
+pbkdf2 = { version = "0.3.0", default-features = false }
 sha2 = "0.8.0"
 x25519-dalek = "0.5.2"
-subtle = "2.1.1"
-zeroize = "0.10.1"
-zeroize_derive = "0.10.0"
-base64 = "0.10.1"
+subtle = "2.2.1"
+zeroize = "1.0.0"
+zeroize_derive = "1.0.0"
+base64 = "0.11.0"
 chacha20poly1305 = "0.2.1"
 aead = "0.1.1"
 

--- a/devolutionscrypto/src/dc_data_blob/dc_ciphertext/dc_ciphertext_v1.rs
+++ b/devolutionscrypto/src/dc_data_blob/dc_ciphertext/dc_ciphertext_v1.rs
@@ -1,3 +1,5 @@
+/// Ciphertext V1: AES256-CBC with HMAC-SHA256
+
 use super::DcHeader;
 use super::DevoCryptoError;
 use super::Result;

--- a/devolutionscrypto/src/dc_data_blob/dc_ciphertext/dc_ciphertext_v1.rs
+++ b/devolutionscrypto/src/dc_data_blob/dc_ciphertext/dc_ciphertext_v1.rs
@@ -62,6 +62,7 @@ impl DcCiphertextV1 {
         pbkdf2::<Hmac<Sha256>>(secret, &salt[0..1], 1, signature_key);
     }
 
+    #[allow(dead_code)]
     pub fn encrypt(data: &[u8], key: &[u8], header: &DcHeader) -> Result<DcCiphertextV1> {
         // Split keys
         let mut encryption_key = vec![0u8; 32];

--- a/devolutionscrypto/src/dc_data_blob/dc_ciphertext/dc_ciphertext_v2.rs
+++ b/devolutionscrypto/src/dc_data_blob/dc_ciphertext/dc_ciphertext_v2.rs
@@ -1,3 +1,5 @@
+/// Ciphertext V2: XChaCha20Poly1305
+
 use super::DcHeader;
 use super::DevoCryptoError;
 use super::Result;

--- a/devolutionscrypto/src/dc_data_blob/dc_ciphertext/dc_ciphertext_v2.rs
+++ b/devolutionscrypto/src/dc_data_blob/dc_ciphertext/dc_ciphertext_v2.rs
@@ -1,0 +1,89 @@
+use super::DevoCryptoError;
+use super::Result;
+
+use std::convert::TryFrom;
+
+use aead::{
+    generic_array::{typenum, GenericArray},
+    Aead, NewAead,
+};
+use chacha20poly1305::XChaCha20Poly1305;
+use rand::{rngs::OsRng, RngCore};
+use sha2::{Digest, Sha256};
+use zeroize::Zeroize;
+
+#[derive(Zeroize)]
+#[zeroize(drop)]
+pub struct DcCiphertextV2 {
+    nonce: Vec<u8>,
+    ciphertext: Vec<u8>,
+}
+
+impl Into<Vec<u8>> for DcCiphertextV2 {
+    fn into(mut self) -> Vec<u8> {
+        let mut data = Vec::new();
+        data.append(&mut self.nonce);
+        data.append(&mut self.ciphertext);
+        data
+    }
+}
+
+impl TryFrom<&[u8]> for DcCiphertextV2 {
+    type Error = DevoCryptoError;
+    fn try_from(data: &[u8]) -> Result<DcCiphertextV2> {
+        if data.len() <= 24 {
+            return Err(DevoCryptoError::InvalidLength);
+        };
+
+        let mut nonce = vec![0u8; 24];
+        let mut ciphertext = vec![0u8; data.len() - 24];
+
+        nonce.copy_from_slice(&data[0..24]);
+        ciphertext.copy_from_slice(&data[24..]);
+
+        Ok(DcCiphertextV2 { nonce, ciphertext })
+    }
+}
+
+impl DcCiphertextV2 {
+    fn derive_key(secret: &[u8]) -> GenericArray<u8, typenum::U32> {
+        let mut hasher = Sha256::new();
+        hasher.input(secret);
+        hasher.result()
+    }
+
+    pub fn encrypt(data: &[u8], key: &[u8]) -> Result<DcCiphertextV2> {
+        // Derive key
+        let mut key = DcCiphertextV2::derive_key(&key);
+
+        // Generate nonce
+        let mut rng = OsRng::new()?;
+        let mut nonce = vec![0u8; 24];
+        rng.fill_bytes(&mut nonce);
+
+        // Encrypt
+        let cipher = XChaCha20Poly1305::new(key);
+        let ciphertext = cipher.encrypt(&GenericArray::from_slice(&nonce), data)?;
+
+        // Zero out the key
+        key.zeroize();
+
+        Ok(DcCiphertextV2 { nonce, ciphertext })
+    }
+
+    pub fn decrypt(&self, key: &[u8]) -> Result<Vec<u8>> {
+        // Derive key
+        let mut key = DcCiphertextV2::derive_key(&key);
+
+        let cipher = XChaCha20Poly1305::new(key);
+        let result = cipher.decrypt(
+            &GenericArray::from_slice(&self.nonce),
+            self.ciphertext.as_slice(),
+        )?;
+
+        // Zeroize the key
+        key.zeroize();
+
+        Ok(result)
+    }
+}

--- a/devolutionscrypto/src/dc_data_blob/dc_ciphertext/mod.rs
+++ b/devolutionscrypto/src/dc_data_blob/dc_ciphertext/mod.rs
@@ -1,41 +1,45 @@
 mod dc_ciphertext_v1;
+mod dc_ciphertext_v2;
 
 use super::DcHeader;
 use super::DevoCryptoError;
 use super::Result;
 
 use self::dc_ciphertext_v1::DcCiphertextV1;
+use self::dc_ciphertext_v2::DcCiphertextV2;
 
 use std::convert::TryFrom as _;
 
 pub const CIPHERTEXT: u16 = 2;
 
 const V1: u16 = 1;
+const V2: u16 = 2;
 
 pub enum DcCiphertext {
     V1(DcCiphertextV1),
+    V2(DcCiphertextV2),
 }
 
 impl DcCiphertext {
     pub fn try_from_header(data: &[u8], header: &DcHeader) -> Result<DcCiphertext> {
         match header.version {
             V1 => Ok(DcCiphertext::V1(DcCiphertextV1::try_from(data)?)),
+            V2 => Ok(DcCiphertext::V2(DcCiphertextV2::try_from(data)?)),
             _ => Err(DevoCryptoError::UnknownVersion),
         }
     }
 
     pub fn encrypt(data: &[u8], key: &[u8], header: &mut DcHeader) -> Result<DcCiphertext> {
         header.data_type = CIPHERTEXT;
-        header.version = V1;
+        header.version = V2;
 
-        Ok(DcCiphertext::V1(DcCiphertextV1::encrypt(
-            data, key, header,
-        )?))
+        Ok(DcCiphertext::V2(DcCiphertextV2::encrypt(data, key)?))
     }
 
     pub fn decrypt(&self, key: &[u8], header: &DcHeader) -> Result<Vec<u8>> {
         match self {
             DcCiphertext::V1(x) => x.decrypt(key, header),
+            DcCiphertext::V2(x) => x.decrypt(key),
         }
     }
 }
@@ -44,6 +48,7 @@ impl Into<Vec<u8>> for DcCiphertext {
     fn into(self) -> Vec<u8> {
         match self {
             DcCiphertext::V1(x) => x.into(),
+            DcCiphertext::V2(x) => x.into(),
         }
     }
 }

--- a/devolutionscrypto/src/dc_data_blob/dc_ciphertext/mod.rs
+++ b/devolutionscrypto/src/dc_data_blob/dc_ciphertext/mod.rs
@@ -33,13 +33,15 @@ impl DcCiphertext {
         header.data_type = CIPHERTEXT;
         header.version = V2;
 
-        Ok(DcCiphertext::V2(DcCiphertextV2::encrypt(data, key)?))
+        Ok(DcCiphertext::V2(DcCiphertextV2::encrypt(
+            data, key, header,
+        )?))
     }
 
     pub fn decrypt(&self, key: &[u8], header: &DcHeader) -> Result<Vec<u8>> {
         match self {
             DcCiphertext::V1(x) => x.decrypt(key, header),
-            DcCiphertext::V2(x) => x.decrypt(key),
+            DcCiphertext::V2(x) => x.decrypt(key, header),
         }
     }
 }

--- a/devolutionscrypto/src/dc_data_blob/mod.rs
+++ b/devolutionscrypto/src/dc_data_blob/mod.rs
@@ -212,14 +212,41 @@ impl DcDataBlob {
 }
 
 #[test]
-fn crypto_test() {
+fn encrypt_decrypt_test() {
     let key = "0123456789abcdefghijkl".as_bytes();
     let data = "This is a very complex string of character that we need to encrypt".as_bytes();
 
-    let encrypted = DcDataBlob::encrypt(data, key).unwrap();
+    let encrypted = DcDataBlob::encrypt(data, &key).unwrap();
+    let encrypted: Vec<u8> = encrypted.into();
+
+    let encrypted = DcDataBlob::try_from(encrypted.as_slice()).unwrap();
     let decrypted = encrypted.decrypt(key).unwrap();
 
     assert_eq!(decrypted, data);
+}
+
+#[test]
+fn decrypt_v1_test() {
+    use base64;
+    
+    let data = base64::decode("DQwCAAAAAQBo87jumRMVMIuTP8cFbFTgwDguKXkBvlkE/rNu4HLRRueQqfCzmXEyGR7qWAKkz4BFFyGedCmQ/xXTW4V7UnV9um1TJClz3yzQy0SQui+1UA==").unwrap();
+    let key = base64::decode("Xk63o/+6TeC63Z4j2HZOOdiGfqjQNJz1PTbQ3/L5nM0=").unwrap();
+    let encrypted = DcDataBlob::try_from(data.as_slice()).unwrap();
+    let decrypted = encrypted.decrypt(&key).unwrap();
+
+    assert_eq!(decrypted, "A secret v1 string".as_bytes());
+}
+
+#[test]
+fn decrypt_v2_test() {
+    use base64;
+    
+    let data = base64::decode("DQwCAAAAAgCcJ6yg2jWt3Zr1ZvenW4/AFi3Xj82IqfvaHmmPzMgzkrTfeKp8Shey3KLLLOhtMU4eNmYBRcAtSPfQ").unwrap();
+    let key = base64::decode("Dipney+DR14k+Bvz/gBJrM19yAerG/0g5iHSm/HcOJU=").unwrap();
+    let encrypted = DcDataBlob::try_from(data.as_slice()).unwrap();
+    let decrypted = encrypted.decrypt(&key).unwrap();
+
+    assert_eq!(decrypted, "A secret v2 string".as_bytes());
 }
 
 #[test]

--- a/devolutionscrypto/src/dc_data_blob/mod.rs
+++ b/devolutionscrypto/src/dc_data_blob/mod.rs
@@ -60,7 +60,7 @@ impl DcDataBlob {
     /// Returns a `DcDataBlob` containing the encrypted data.
     /// # Example
     /// ```rust
-    /// use devocrypto::DcDataBlob;
+    /// use devolutionscrypto::DcDataBlob;
     ///
     /// let data = b"somesecretdata";
     /// let key = b"somesecretkey";
@@ -80,7 +80,7 @@ impl DcDataBlob {
     /// Returns the decrypted data.
     /// # Example
     /// ```rust
-    /// use devocrypto::DcDataBlob;
+    /// use devolutionscrypto::DcDataBlob;
     ///
     /// let data = b"somesecretdata";
     /// let key = b"somesecretkey";
@@ -88,7 +88,7 @@ impl DcDataBlob {
     /// let encrypted_data = DcDataBlob::encrypt(data, key).unwrap();
     /// let decrypted_data = encrypted_data.decrypt(key).unwrap();
     ///
-    /// assert_eq!(data, decrypted_data);
+    /// assert_eq!(data.to_vec(), decrypted_data);
     ///```
     pub fn decrypt(&self, key: &[u8]) -> Result<Vec<u8>> {
         self.payload.decrypt(key, &self.header)
@@ -123,13 +123,13 @@ impl DcDataBlob {
     /// Returns true if the password matches and false if it doesn't.
     /// # Example
     /// ```rust
-    /// use devocrypto::DcDataBlob;
+    /// use devolutionscrypto::DcDataBlob;
     ///
     /// let password = b"somesuperstrongpa$$w0rd!";
     ///
-    /// let hashed_password = DcDataBlob::hash_password(password, 10000);
-    /// assert!(hashed_password.verify(b"somesuperstrongpa$$w0rd!").unwrap());
-    /// assert!(!hashed_password.verify(b"someweakpa$$w0rd!").unwrap());
+    /// let hashed_password = DcDataBlob::hash_password(password, 10000).unwrap();
+    /// assert!(hashed_password.verify_password(b"somesuperstrongpa$$w0rd!").unwrap());
+    /// assert!(!hashed_password.verify_password(b"someweakpa$$w0rd!").unwrap());
     /// ```
     pub fn verify_password(&self, password: &[u8]) -> Result<bool> {
         self.payload.verify_password(password)
@@ -140,7 +140,7 @@ impl DcDataBlob {
     /// Returns, in order, the private key and the public key in a `DcDataBlob`.
     /// # Example
     /// ```rust
-    /// use devocrypto::DcDataBlob;
+    /// use devolutionscrypto::DcDataBlob;
     ///
     /// let (private, public) = DcDataBlob::generate_key_exchange().unwrap();
     /// ```
@@ -170,29 +170,36 @@ impl DcDataBlob {
     ///     as an encryption key between the two peers.
     /// # Example
     /// ```rust
-    /// use devocrypto::DcDataBlob;
+    /// use std::convert::TryFrom as _;
+    /// use devolutionscrypto::DcDataBlob;
+    /// # fn send_key_to_alice(_: &[u8]) {}
+    /// # fn send_key_to_bob(_: &[u8]) {}
+    /// # fn receive_key_from_alice() {}
+    /// # fn receive_key_from_bob() {}
     ///
     /// // This happens on Bob's side.
     /// let (bob_priv, bob_pub) = DcDataBlob::generate_key_exchange().unwrap();
     /// let bob_serialized_pub: Vec<u8> = bob_pub.into();
     ///
-    /// send_key_to_alice(bob_serialized_pub);
+    /// send_key_to_alice(&bob_serialized_pub);
     ///
     /// // This happens on Alice's side.
     /// let (alice_priv, alice_pub) = DcDataBlob::generate_key_exchange().unwrap();
     /// let alice_serialized_pub: Vec<u8> = alice_pub.into();
     ///
-    /// send_key_to_bob(alice_serialized_pub);
+    /// send_key_to_bob(&alice_serialized_pub);
     ///
     /// // Bob can now generate the shared secret.
     /// let alice_received_serialized_pub = receive_key_from_alice();
-    /// let alice_received_pub = DcDataBlob::try_from(&alice_received_serialized_pub).unwrap();
+    /// # let alice_received_serialized_pub = alice_serialized_pub;
+    /// let alice_received_pub = DcDataBlob::try_from(alice_received_serialized_pub.as_slice()).unwrap();
     ///
     /// let bob_shared = bob_priv.mix_key_exchange(alice_received_pub).unwrap();
     ///
     /// // Alice can now generate the shared secret
     /// let bob_received_serialized_pub = receive_key_from_bob();
-    /// let bob_received_pub = DcDataBlob::try_from(&bob_received_serialized_pub).unwrap();
+    /// # let bob_received_serialized_pub = bob_serialized_pub;
+    /// let bob_received_pub = DcDataBlob::try_from(bob_received_serialized_pub.as_slice()).unwrap();
     ///
     /// let alice_shared = alice_priv.mix_key_exchange(bob_received_pub).unwrap();
     ///

--- a/devolutionscrypto/src/devocrypto_errors.rs
+++ b/devolutionscrypto/src/devocrypto_errors.rs
@@ -120,6 +120,12 @@ impl From<BlockModeError> for DevoCryptoError {
     }
 }
 
+impl From<aead::Error> for DevoCryptoError {
+    fn from(_error: aead::Error) -> DevoCryptoError {
+        DevoCryptoError::CryptoError
+    }
+}
+
 impl From<rand::Error> for DevoCryptoError {
     fn from(_error: rand::Error) -> DevoCryptoError {
         DevoCryptoError::RandomError

--- a/devolutionscrypto/src/ffi.rs
+++ b/devolutionscrypto/src/ffi.rs
@@ -8,7 +8,7 @@
 //! The Size functions must be called to get the required length of the returned array before
 //!     calling it.
 
-use super::devocrypto;
+use super::utils;
 use super::DcDataBlob;
 use super::DevoCryptoError;
 
@@ -346,7 +346,7 @@ pub unsafe extern "C" fn GenerateKey(key: *mut u8, key_length: usize) -> i64 {
 
     let key = slice::from_raw_parts_mut(key, key_length);
 
-    match devocrypto::generate_key(key_length) {
+    match utils::generate_key(key_length) {
         Ok(mut k) => {
             key.copy_from_slice(&k);
             k.zeroize();
@@ -391,7 +391,7 @@ pub unsafe extern "C" fn DeriveKey(
     let key = slice::from_raw_parts(key, key_length);
     let result = slice::from_raw_parts_mut(result, result_length);
 
-    let mut native_result = devocrypto::derive_key(&key, &salt, niterations, result_length);
+    let mut native_result = utils::derive_key(&key, &salt, niterations, result_length);
     result.copy_from_slice(&native_result);
     native_result.zeroize();
     0

--- a/devolutionscrypto/src/ffi.rs
+++ b/devolutionscrypto/src/ffi.rs
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn Encrypt(
 /// Returns the length of the ciphertext to input as `result_length` in `Encrypt()`.
 #[no_mangle]
 pub extern "C" fn EncryptSize(data_length: usize) -> i64 {
-    (8 + 16 + (data_length / 16 + 1) * 16 + 32) as i64 // Header + IV + data(padded to 16) + HMAC
+    (8 + 24 + data_length + 16) as i64 // Header + nonce + data + Poly1305 tag
 }
 
 

--- a/devolutionscrypto/src/lib.rs
+++ b/devolutionscrypto/src/lib.rs
@@ -5,7 +5,7 @@ extern crate cfg_if;
 extern crate zeroize_derive;
 
 mod dc_data_blob;
-pub mod devocrypto;
+pub mod utils;
 
 type Result<T> = std::result::Result<T, devocrypto_errors::DevoCryptoError>;
 mod devocrypto_errors;

--- a/devolutionscrypto/src/utils.rs
+++ b/devolutionscrypto/src/utils.rs
@@ -12,9 +12,9 @@ use sha2::Sha256;
 ///  * `length` - Length of the key.
 /// # Example
 /// ```
-/// use devocrypto::generate_key;
+/// use devolutionscrypto::utils::generate_key;
 ///
-/// let key = generate_key(32);
+/// let key = generate_key(32).unwrap();
 /// assert_eq!(32, key.len());
 /// ```
 pub fn generate_key(length: usize) -> Result<Vec<u8>> {
@@ -33,7 +33,7 @@ pub fn generate_key(length: usize) -> Result<Vec<u8>> {
 ///  * `length` - Length of the desired key.
 /// # Example
 /// ```
-/// use devocrypto::derive_key;
+/// use devolutionscrypto::utils::derive_key;
 /// let key = b"this is a secret password";
 /// let salt = b"this is a salt";
 /// let iterations = 10000;

--- a/devolutionscrypto/src/wasm.rs
+++ b/devolutionscrypto/src/wasm.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom as _;
 
 use wasm_bindgen::prelude::*;
 
-use super::devocrypto;
+use super::utils;
 use super::DcDataBlob;
 
 use zeroize::Zeroize as _;
@@ -68,10 +68,10 @@ pub fn mix_key_exchange(private: &[u8], public: &[u8]) -> Vec<u8> {
 
 #[wasm_bindgen]
 pub fn generate_key(length: usize) -> Vec<u8> {
-    devocrypto::generate_key(length).unwrap()
+    utils::generate_key(length).unwrap()
 }
 
 #[wasm_bindgen]
 pub fn derive_key(key: &[u8], salt: &[u8], iterations: usize, length: usize) -> Vec<u8> {
-    devocrypto::derive_key(key, salt, iterations, length)
+    utils::derive_key(key, salt, iterations, length)
 }

--- a/wrappers/csharp/Native.cs
+++ b/wrappers/csharp/Native.cs
@@ -188,33 +188,6 @@ namespace Devolutions.Cryptography
             }
         }
 
-        public static byte[] GenerateKey(Action<Enum> error = null)
-        {
-            try
-            {
-                uint keySize = KeySizeNative();
-
-                byte[] key = new byte[keySize];
-
-                long res = GenerateKeyNative(key, (UIntPtr)keySize);
-
-                if (res < 0)
-                {
-                    HandleError(res, error);
-
-                    return null;
-                }
-
-                return key;
-            }
-            catch
-            {
-                error?.Invoke(ManagedError.Error);
-
-                return null;
-            }
-        }
-
         public static byte[] GenerateKey(uint keySize, Action<Enum> error = null)
         {
             try
@@ -383,7 +356,7 @@ namespace Devolutions.Cryptography
                 throw new Exception();
             }
 
-            byte[] generateKey = GenerateKey();
+            byte[] generateKey = GenerateKey(32);
 
             byte[] dericeKeyResult = DeriveKey(generateKey, null);
 


### PR DESCRIPTION
The version 2 of our encryption scheme. This upgrades from AES256-CBC-HMAC to XChaCha20Poly1305 for various reasons.

1. It simplifies the code a lot, since XChaCha20Poly1305 is an AEAD and ensures the integrity of the data without a separate HMAC. It also reduce the chance of error on our part.
2. Faster than the old implementation, especially on non-x86 architectures like mobile devices and webassembly.
3. Side-channel attacks are less probable since ChaCha20 was designed with them in mind, as opposed to AES. This is, once again, especially true with non-x86 platform since they can't rely on 
AES-NI and AES is more prone to unwanted compiler optimization and other similar problems.

Eventually, we will add an flag for FIPS compliance and use AES-GCM in those cases.

Note that I bumped the version to 0.2.0, as described by semver, since an upgrade of the library on a client would break the data for older clients who didn't update and don't know how to decrypt it.