### PR TITLE
Multiple improvement for WebAssembly

### DIFF
--- a/devolutionscrypto/src/devocrypto_errors.rs
+++ b/devolutionscrypto/src/devocrypto_errors.rs
@@ -168,8 +168,7 @@ impl From<DevoCryptoError> for JsValue {
     fn from(error: DevoCryptoError) -> JsValue {
         let js_error = js_sys::Error::new(error.description());
 
-        // This line is commented as the method doesn't work in the library right now.
-        //js_error.set_name("allo");
+        js_error.set_name(error.name());
         js_error.into()
     }
 }

--- a/devolutionscrypto/src/wasm.rs
+++ b/devolutionscrypto/src/wasm.rs
@@ -87,7 +87,7 @@ pub fn base64encode(data: &[u8]) -> String {
 }
 
 #[wasm_bindgen]
-pub fn base64decode(data: String) -> Result<Vec<u8>, JsValue> {
+pub fn base64decode(data: &str) -> Result<Vec<u8>, JsValue> {
     match base64::decode(&data) {
         Ok(res) => Ok(res),
         Err(e) => {

--- a/devolutionscrypto/src/wasm.rs
+++ b/devolutionscrypto/src/wasm.rs
@@ -92,6 +92,7 @@ pub fn base64decode(data: String) -> Result<Vec<u8>, JsValue> {
         Ok(res) => Ok(res),
         Err(e) => {
             let error = js_sys::Error::new(&format!("{}", e));
+            error.set_name("Base64Error");
             Err(error.into())
         }
     }

--- a/devolutionscrypto/src/wasm.rs
+++ b/devolutionscrypto/src/wasm.rs
@@ -91,8 +91,8 @@ pub fn base64decode(data: String) -> Result<Vec<u8>, JsValue> {
     match base64::decode(&data) {
         Ok(res) => Ok(res),
         Err(e) => {
-            let error = JsValue::from_str(&format!("{}", e));
-            Err(error)
+            let error = js_sys::Error::new(&format!("{}", e));
+            Err(error.into())
         }
     }
 }

--- a/devolutionscrypto/tests/web.rs
+++ b/devolutionscrypto/tests/web.rs
@@ -6,23 +6,69 @@ cfg_if! {
         extern crate base64;
         extern crate wasm_bindgen_test;
 
-        use std::convert::TryFrom as _;
         use wasm_bindgen_test::*;
 
-        use devolutionscrypto::DcDataBlob;
+        use devolutionscrypto::wasm;
 
         #[wasm_bindgen_test]
         fn test_encrypt_decrypt() {
             let data = "test".as_bytes();
             let key = base64::decode("dpxbute8LZ4tqpw1pVWyBvMzOtm+OJQPcIsU52+FFZU=").unwrap();
 
-            let ciphertext = DcDataBlob::encrypt(data, &key, 0).unwrap();
-            let ciphertext_vec: Vec<u8> = ciphertext.into();
-
-            let ciphertext = DcDataBlob::try_from(ciphertext_vec.as_slice()).unwrap();
-            let plaintext = ciphertext.decrypt(&key).unwrap();
+            let ciphertext = wasm::encrypt(data, &key, None).unwrap();
+            let plaintext = wasm::decrypt(&ciphertext, &key).unwrap();
 
             assert_eq!(plaintext, data);
+        }
+
+        #[wasm_bindgen_test]
+        fn test_hash_password() {
+            let password = "ThisIsAGoodPassword123".as_bytes();
+
+            let hash = wasm::hash_password(password, Some(123)).unwrap();
+            assert!(wasm::verify_password(password, &hash).unwrap());
+
+            let bad_password = "thisisabadpassword1234".as_bytes();
+            assert!(!wasm::verify_password(bad_password, &hash).unwrap());
+        }
+
+        #[wasm_bindgen_test]
+        fn test_key_exchange() {
+            let bob_keypair = wasm::generate_key_exchange().unwrap();
+            let alice_keypair = wasm::generate_key_exchange().unwrap();
+
+            let bob_key = wasm::mix_key_exchange(&bob_keypair.private(), &alice_keypair.public()).unwrap();
+            let alice_key = wasm::mix_key_exchange(&alice_keypair.private(), &bob_keypair.public()).unwrap();
+
+            assert_ne!(bob_key.len(), 0);
+            assert_eq!(bob_key, alice_key);
+        }
+
+        #[wasm_bindgen_test]
+        fn test_generate_key() {
+            let key = wasm::generate_key(Some(10)).unwrap();
+
+            assert_eq!(key.len(), 10);
+            assert_ne!(&key, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        }
+
+        #[wasm_bindgen_test]
+        fn test_base64() {
+            let plain = "ThIs1saTesT";
+            let encoded = wasm::base64encode(plain.as_bytes());
+            assert_eq!(&encoded, "VGhJczFzYVRlc1Q=");
+
+            let decoded = wasm::base64decode(&encoded).unwrap();
+            assert_eq!(decoded.as_slice(), plain.as_bytes());
+        }
+
+        #[wasm_bindgen_test]
+        fn test_derive_key() {
+            let password = "ThisIsAGoodPassword123".as_bytes();
+            let salt = base64::decode("u4tv/i1228VOqoZWITseoQ==").unwrap();
+            let key = wasm::derive_key(password, &salt, 123, 32);
+
+            assert_eq!(key, base64::decode("RfIYPWWXRSm/SWjVXvQq1Z3n/mzxGeu/y396bAuYWTI=").unwrap());
         }
     }
 }

--- a/wrappers/wasm/README.md
+++ b/wrappers/wasm/README.md
@@ -26,3 +26,6 @@ Refer to the `example/` folder for an example on how to use it with webpack. I'l
 ## Current State
 Currently, the webassembly module implements the same functionnalities as the native version, while keeping the build system pretty easy to use. It is also part of the CI. On a security standpoint it is as secure as the native one and is also pretty fast.  
 Please note however that we still consider it to be beta as the API is not final yet and might still change, so we won't publish it to npm for now.
+
+## Known Issue
+On firefox, exception shows up as `Error` in the console if not caught, but the value of `error.name` is the right one, so you can still try/catch depending on the error name but it can be misleading for developpers.


### PR DESCRIPTION
- Added exception handling for Base64
- Added exception name for all exceptions
- `base64decode` now takes a `&str` instead of a `String` as argument.
- Added integration tests for all the exported functions.