### PR TITLE
Use an Option for the version number

### DIFF
--- a/devolutions-crypto/src/dc_data_blob/dc_ciphertext/mod.rs
+++ b/devolutions-crypto/src/dc_data_blob/dc_ciphertext/mod.rs
@@ -12,7 +12,6 @@ use std::convert::TryFrom as _;
 
 pub const CIPHERTEXT: u16 = 2;
 
-const DEFAULT: u16 = 0;
 const V1: u16 = 1;
 const V2: u16 = 2;
 
@@ -34,18 +33,18 @@ impl DcCiphertext {
         data: &[u8],
         key: &[u8],
         header: &mut DcHeader,
-        version: u16,
+        version: Option<u16>,
     ) -> Result<DcCiphertext> {
         header.data_type = CIPHERTEXT;
 
         match version {
-            V1 => {
+            Some(V1) => {
                 header.version = V1;
                 Ok(DcCiphertext::V1(DcCiphertextV1::encrypt(
                     data, key, header,
                 )?))
             }
-            V2 | DEFAULT => {
+            Some(V2) | None => {
                 header.version = V2;
                 Ok(DcCiphertext::V2(DcCiphertextV2::encrypt(
                     data, key, header,

--- a/devolutions-crypto/src/dc_data_blob/dc_payload.rs
+++ b/devolutions-crypto/src/dc_data_blob/dc_payload.rs
@@ -29,7 +29,7 @@ impl DcPayload {
         data: &[u8],
         key: &[u8],
         header: &mut DcHeader,
-        version: u16,
+        version: Option<u16>,
     ) -> Result<DcPayload> {
         Ok(DcPayload::Ciphertext(DcCiphertext::encrypt(
             data, key, header, version,

--- a/devolutions-crypto/src/dc_data_blob/mod.rs
+++ b/devolutions-crypto/src/dc_data_blob/mod.rs
@@ -66,9 +66,9 @@ impl DcDataBlob {
     /// let data = b"somesecretdata";
     /// let key = b"somesecretkey";
     ///
-    /// let encrypted_data = DcDataBlob::encrypt(data, key, 0).unwrap();
+    /// let encrypted_data = DcDataBlob::encrypt(data, key, None).unwrap();
     /// ```
-    pub fn encrypt(data: &[u8], key: &[u8], version: u16) -> Result<DcDataBlob> {
+    pub fn encrypt(data: &[u8], key: &[u8], version: Option<u16>) -> Result<DcDataBlob> {
         let mut header = DcHeader::new();
         let payload = DcPayload::encrypt(data, key, &mut header, version)?;
         Ok(DcDataBlob { header, payload })
@@ -86,7 +86,7 @@ impl DcDataBlob {
     /// let data = b"somesecretdata";
     /// let key = b"somesecretkey";
     ///
-    /// let encrypted_data = DcDataBlob::encrypt(data, key, 0).unwrap();
+    /// let encrypted_data = DcDataBlob::encrypt(data, key, None).unwrap();
     /// let decrypted_data = encrypted_data.decrypt(key).unwrap();
     ///
     /// assert_eq!(data.to_vec(), decrypted_data);
@@ -217,7 +217,7 @@ fn encrypt_decrypt_test() {
     let key = "0123456789abcdefghijkl".as_bytes();
     let data = "This is a very complex string of character that we need to encrypt".as_bytes();
 
-    let encrypted = DcDataBlob::encrypt(data, &key, 0).unwrap();
+    let encrypted = DcDataBlob::encrypt(data, &key, None).unwrap();
     let encrypted: Vec<u8> = encrypted.into();
 
     let encrypted = DcDataBlob::try_from(encrypted.as_slice()).unwrap();
@@ -233,7 +233,7 @@ fn encrypt_v1_test() {
     let data = "testdata".as_bytes();
     let key = base64::decode("Sr98VxTc424QFZDH2csZni/n5tKk2/d4ow7iGUqd5HQ=").unwrap();
 
-    let encrypted = DcDataBlob::encrypt(data, &key, 1).unwrap();
+    let encrypted = DcDataBlob::encrypt(data, &key, Some(1)).unwrap();
 
     assert_eq!(encrypted.header.version, 1);
 
@@ -252,7 +252,7 @@ fn encrypt_v2_test() {
     let data = "testdata".as_bytes();
     let key = base64::decode("HOPWSC5oA9Az9SAnuwGI3nT3Dx/z2qtHBQI1k2WvVFo=").unwrap();
 
-    let encrypted = DcDataBlob::encrypt(data, &key, 2).unwrap();
+    let encrypted = DcDataBlob::encrypt(data, &key, Some(2)).unwrap();
 
     assert_eq!(encrypted.header.version, 2);
 

--- a/devolutions-crypto/src/ffi.rs
+++ b/devolutions-crypto/src/ffi.rs
@@ -56,6 +56,11 @@ pub unsafe extern "C" fn Encrypt(
     let key = slice::from_raw_parts(key, key_length);
     let result = slice::from_raw_parts_mut(result, result_length);
 
+    let version = match version {
+        0 => None,
+        v => Some(v),
+    };
+
     match DcDataBlob::encrypt(data, key, version) {
         Ok(res) => {
             let mut res: Vec<u8> = res.into();
@@ -474,7 +479,7 @@ pub extern "C" fn VersionSize() -> i64 {
 /// # Returns
 /// Returns the size, in bytes, of the output buffer.
 #[no_mangle]
-pub unsafe extern "C" fn Version(output: *mut u8, output_length: usize,) -> i64 {
+pub unsafe extern "C" fn Version(output: *mut u8, output_length: usize) -> i64 {
     if output.is_null() {
         return DevoCryptoError::NullPointer.error_code();
     };
@@ -493,12 +498,16 @@ fn test_encrypt_length() {
     let one_full_block = b"0123456789abcdef";
     let multiple_blocks = b"0123456789abcdefghijkl";
 
-    let length_zero_enc: Vec<u8> = DcDataBlob::encrypt(length_zero, key, 0).unwrap().into();
-    let length_one_block_enc: Vec<u8> = DcDataBlob::encrypt(length_one_block, key, 0)
+    let length_zero_enc: Vec<u8> = DcDataBlob::encrypt(length_zero, key, None).unwrap().into();
+    let length_one_block_enc: Vec<u8> = DcDataBlob::encrypt(length_one_block, key, None)
         .unwrap()
         .into();
-    let one_full_block_enc: Vec<u8> = DcDataBlob::encrypt(one_full_block, key, 0).unwrap().into();
-    let multiple_blocks_enc: Vec<u8> = DcDataBlob::encrypt(multiple_blocks, key, 0).unwrap().into();
+    let one_full_block_enc: Vec<u8> = DcDataBlob::encrypt(one_full_block, key, None)
+        .unwrap()
+        .into();
+    let multiple_blocks_enc: Vec<u8> = DcDataBlob::encrypt(multiple_blocks, key, None)
+        .unwrap()
+        .into();
 
     assert_eq!(
         length_zero_enc.len() as i64,

--- a/devolutions-crypto/src/wasm.rs
+++ b/devolutions-crypto/src/wasm.rs
@@ -33,7 +33,6 @@ impl Drop for KeyPair {
 
 #[wasm_bindgen]
 pub fn encrypt(data: &[u8], key: &[u8], version: Option<u16>) -> Result<Vec<u8>, JsValue> {
-    let version = version.unwrap_or(0);
     Ok(DcDataBlob::encrypt(&data, &key, version)?.into())
 }
 

--- a/wrappers/wasm/example/package.json
+++ b/wrappers/wasm/example/package.json
@@ -18,7 +18,7 @@
   "author": "Philippe Dugre <pdugre@devolutions.net>",
   "license": "(MIT OR Apache-2.0)",
   "dependencies": {
-    "devolutions-crypto": "0.2.0"
+    "devolutions-crypto": "file:../pkg/"
   },
   "devDependencies": {
     "webpack": "^4.29.3",


### PR DESCRIPTION
Use an `Option<u16>` instead of a `u16` for the version number, for the rust API.