### PR TITLE
Fix unwanted dll copied in rdm

### DIFF
--- a/devolutions-crypto/Cargo.toml
+++ b/devolutions-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devolutions-crypto"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Philippe Dugre <pdugre@devolutions.net>", "Mathieu Morrissette <mmorrissette@devolutions.net>"]
 edition = "2018"
 readme = "../README.md"

--- a/devolutions-crypto/ios/Cargo.toml
+++ b/devolutions-crypto/ios/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devolutions-crypto"
-version = "0.3.0"
+version = "0.3.3"
 authors = ["Philippe Dugre <pdugre@devolutions.net>", "Mathieu Morrissette <mmorrissette@devolutions.net>"]
 edition = "2018"
 readme = "../README.md"

--- a/wrappers/csharp/nuget/rdm/Devolutions.Crypto.Windows.RDM.nuspec
+++ b/wrappers/csharp/nuget/rdm/Devolutions.Crypto.Windows.RDM.nuspec
@@ -25,8 +25,8 @@
     <file src="../../rdm/bin/Devolutions.Crypto.dll" target="lib/netstandard2.0/Devolutions.Crypto.dll" />
     <file src="../../rdm/bin/Devolutions.Crypto.pdb" target="lib/netstandard2.0/Devolutions.Crypto.pdb" />
 
-    <file src="../../rdm/bin/x64/DevolutionsCrypto.dll" target="runtimes/win-x64/native/DevolutionsCrypto.dll"/>
-    <file src="../../rdm/bin/x86/DevolutionsCrypto.dll" target="runtimes/win-x86/native/DevolutionsCrypto.dll"/>
+    <file src="../../rdm/bin/x64/DevolutionsCrypto.dll" target="runtime/win-x64/native/DevolutionsCrypto.dll"/>
+    <file src="../../rdm/bin/x86/DevolutionsCrypto.dll" target="runtime/win-x86/native/DevolutionsCrypto.dll"/>
 
     <file src="Devolutions.Crypto.Windows.RDM.targets" target="build/net45/Devolutions.Crypto.Windows.RDM.targets"/>
 </files>

--- a/wrappers/csharp/nuget/rdm/Devolutions.Crypto.Windows.RDM.targets
+++ b/wrappers/csharp/nuget/rdm/Devolutions.Crypto.Windows.RDM.targets
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\DevolutionsCrypto.dll">
+        <Content Include="$(MSBuildThisFileDirectory)..\..\runtime\win-x86\native\DevolutionsCrypto.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>\x86\DevolutionsCrypto.dll</Link>
         </Content>
 
-        <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\DevolutionsCrypto.dll">
+        <Content Include="$(MSBuildThisFileDirectory)..\..\runtime\win-x64\native\DevolutionsCrypto.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <Link>\x64\DevolutionsCrypto.dll</Link>
         </Content>


### PR DESCRIPTION
Since RDM uses package reference, dlls in the runtimes folder get copied in the root folder.
Using package.config would solve the issue but it is deprecated.

What I did is rename the runtimes folder so that they don't get copied over.