### PR TITLE
Added IE Build Script Using ASM.JS

### DIFF
--- a/wrappers/wasm/ie_build.sh
+++ b/wrappers/wasm/ie_build.sh
@@ -1,0 +1,6 @@
+wasm2js devolutions_crypto_bg.wasm -o devolutions_crypto_bg.js
+sed -i 's/export var /export var \_\_/' devolutions_crypto_bg.js
+sed -i '/^import {/ d' devolutions_crypto_bg.js
+sed -i '/^import \* as wasm/ d' devolutions_crypto.js
+sed -i 's/wasm\./__/' devolutions_crypto.js
+cat devolutions_crypto_bg.js >> devolutions_crypto.js


### PR DESCRIPTION
The official documented way to create an package that works on Internet Explorer and older browser that doesn't support WebAssembly doesn't work out of the box because of a circular dependency. While there are no automated way I know to fix this, we can at least automate the manual steps we do normally to get it working.

This script generates a javascript file from the WASM file, fixes a bunch of things using `sed` and merge the two files to remove the circular dependency. It will probably break after an update of either `wasm-bindgen` or `wasm2js`, but for now it's better than doing it manually.