### PR TITLE
Improved Typescript Api

### DIFF
--- a/devolutions-crypto/src/argon2parameters.rs
+++ b/devolutions-crypto/src/argon2parameters.rs
@@ -20,7 +20,7 @@ use super::Result;
 /// You can save it along the user information.
 /// If the hash should never be computed in a non-threaded environment,
 ///  you can raise the "lanes" value to enable multi-threading.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(inspectable))]
 #[derive(Clone)]
 pub struct Argon2Parameters {
     /// Length of the desired hash

--- a/wrappers/wasm/example/index.js
+++ b/wrappers/wasm/example/index.js
@@ -14,8 +14,8 @@ var keypair = devolutionsCrypto.deriveKeyPair(enc.encode("pass123"), params);
 console.log(devolutionsCrypto.base64encode(keypair.private.bytes))
 console.log(devolutionsCrypto.base64encode(keypair.public.bytes))
 
-var public_key = devolutionsCrypto.PublicKey.from(keypair.public.bytes);
-var private_key = devolutionsCrypto.PrivateKey.from(keypair.private.bytes);
+var public_key = devolutionsCrypto.PublicKey.fromBytes(keypair.public.bytes);
+var private_key = devolutionsCrypto.PrivateKey.fromBytes(keypair.private.bytes);
 
 var asymmetric_ciphertext = devolutionsCrypto.encryptAsymmetric(enc.encode("test_data"), public_key)
 console.log(devolutionsCrypto.base64encode(asymmetric_ciphertext));

--- a/wrappers/wasm/tests/tests/asymmetric.ts
+++ b/wrappers/wasm/tests/tests/asymmetric.ts
@@ -25,7 +25,7 @@ describe('deriveKeyPair', () => {
     const derivedKeyPair1: KeyPair = deriveKeyPair(password, parameters)
 
     const parametersBytes: Uint8Array = parameters.bytes
-    parameters = Argon2Parameters.from(parametersBytes)
+    parameters = Argon2Parameters.fromBytes(parametersBytes)
 
     const derivedKeyPair2: KeyPair = deriveKeyPair(password, parameters)
 
@@ -139,8 +139,8 @@ describe('KeyPair serialization', () => {
     const privateKeyBytes: Uint8Array = keypair.private.bytes
     const publicKeyBytes: Uint8Array = keypair.public.bytes
 
-    const privateKey: PrivateKey = PrivateKey.from(privateKeyBytes)
-    const publicKey: PublicKey = PublicKey.from(publicKeyBytes)
+    const privateKey: PrivateKey = PrivateKey.fromBytes(privateKeyBytes)
+    const publicKey: PublicKey = PublicKey.fromBytes(publicKeyBytes)
 
     expect(privateKey.bytes).to.eql(privateKeyBytes)
     expect(publicKey.bytes).to.eql(publicKeyBytes)
@@ -153,9 +153,9 @@ describe('KeyPair serialization', () => {
 
     const symmetricKey: Uint8Array = generateKey()
 
-    expect(() => PrivateKey.from(publicKeyBytes)).to.throw()
-    expect(() => PublicKey.from(privateKeyBytes)).to.throw()
-    expect(() => PrivateKey.from(symmetricKey)).to.throw()
-    expect(() => PublicKey.from(symmetricKey)).to.throw()
+    expect(() => PrivateKey.fromBytes(publicKeyBytes)).to.throw()
+    expect(() => PublicKey.fromBytes(privateKeyBytes)).to.throw()
+    expect(() => PrivateKey.fromBytes(symmetricKey)).to.throw()
+    expect(() => PublicKey.fromBytes(symmetricKey)).to.throw()
   })
 })

--- a/wrappers/wasm/tests/tests/conformity.ts
+++ b/wrappers/wasm/tests/tests/conformity.ts
@@ -38,7 +38,7 @@ describe('Conformity Tests', () => {
   })
 
   it('Derive Keypair', () => {
-    const parameters: Argon2Parameters = Argon2Parameters.from(base64decode('AQAAACAAAAABAAAAIAAAAAEAAAACEwAAAAAQAAAAimFBkm3f8+f+YfLRnF5OoQ=='))
+    const parameters: Argon2Parameters = Argon2Parameters.fromBytes(base64decode('AQAAACAAAAABAAAAIAAAAAEAAAACEwAAAAAQAAAAimFBkm3f8+f+YfLRnF5OoQ=='))
     const keypair: KeyPair = deriveKeyPair(encoder.encode('password'), parameters)
 
     expect(keypair.private.bytes).to.eql(base64decode('DQwBAAEAAQAAwQ3oJvU6bq2iZlJwAzvbmqJczNrFoeWPeIyJP9SSbQ=='))
@@ -46,7 +46,7 @@ describe('Conformity Tests', () => {
   })
 
   it('Asymmetric Decrypt V2', () => {
-    const privateKey: PrivateKey = PrivateKey.from(base64decode('DQwBAAEAAQAAwQ3oJvU6bq2iZlJwAzvbmqJczNrFoeWPeIyJP9SSbQ=='))
+    const privateKey: PrivateKey = PrivateKey.fromBytes(base64decode('DQwBAAEAAQAAwQ3oJvU6bq2iZlJwAzvbmqJczNrFoeWPeIyJP9SSbQ=='))
     const result: Uint8Array = decryptAsymmetric(base64decode('DQwCAAIAAgCIG9L2MTiumytn7H/p5I3aGVdhV3WUL4i8nIeMWIJ1YRbNQ6lEiQDAyfYhbs6gg1cD7+5Ft2Q5cm7ArsGfiFYWnscm1y7a8tAGfjFFTonzrg=='), privateKey)
 
     expect(decoder.decode(result)).to.eql('testdata')

--- a/wrappers/wasm/tests/tests/secret-sharing.ts
+++ b/wrappers/wasm/tests/tests/secret-sharing.ts
@@ -4,11 +4,11 @@ import { describe, it } from 'mocha'
 
 describe('secretSharing', () => {
   it('should be able to retrieve the same 32 bytes shared key', () => {
-    const shares: [number][] = generateSharedKey(5, 3, 32)
+    const shares: Uint8Array[] = generateSharedKey(5, 3, 32)
 
-    const sharesGroup1: [number][] = shares.slice(0, 3)
-    const sharesGroup2: [number][] = shares.slice(1, 4)
-    const sharesGroup3: [number][] = shares.slice(2, 5)
+    const sharesGroup1: Uint8Array[] = shares.slice(0, 3)
+    const sharesGroup2: Uint8Array[] = shares.slice(1, 4)
+    const sharesGroup3: Uint8Array[] = shares.slice(2, 5)
 
     const key1: Uint8Array = joinShares(sharesGroup1)
     const key2: Uint8Array = joinShares(sharesGroup2)
@@ -21,10 +21,10 @@ describe('secretSharing', () => {
   })
 
   it('should be able to retrieve the same 41 bytes shared key', () => {
-    const shares: [number][] = generateSharedKey(5, 3, 41)
+    const shares: Uint8Array[] = generateSharedKey(5, 3, 41)
 
-    const sharesGroup1: [number][] = shares.slice(0, 3)
-    const sharesGroup2: [number][] = shares.slice(2, 5)
+    const sharesGroup1: Uint8Array[] = shares.slice(0, 3)
+    const sharesGroup2: Uint8Array[] = shares.slice(2, 5)
 
     const key1: Uint8Array = joinShares(sharesGroup1)
     const key2: Uint8Array = joinShares(sharesGroup2)
@@ -39,8 +39,8 @@ describe('secretSharing', () => {
   })
 
   it('should throw an error if there is not enough shares', () => {
-    const shares: [number][] = generateSharedKey(5, 3, 32)
-    const sharesGroup: [number][] = shares.slice(0, 2)
+    const shares: Uint8Array[] = generateSharedKey(5, 3, 32)
+    const sharesGroup: Uint8Array[] = shares.slice(0, 2)
 
     expect(() => joinShares(sharesGroup)).to.throw()
   })


### PR DESCRIPTION
1. Changed the `from` to `fromBytes` in case we need to overload it later.
2. Overriden Typescript generation to expose `Uint8Araay[]` types instead of `any`
3. Added `toString()` and `toJSON()` methods to exported struct.