### PR TITLE
Fix A Bug In The Release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -502,7 +502,6 @@ stages:
     - task: CopyFiles@2
       inputs:
         contents: 'wrappers/wasm/dist/**'
-        flattenFolders: true
         targetFolder: $(Build.ArtifactStagingDirectory)
 
     - task: PublishBuildArtifacts@1


### PR DESCRIPTION
Because of the flatten option int he build pipeline, we couldn't have both NodeJs and Webpack wasm packages and we instead got one of them randomly or a broken mix of the two. This aims to fix this.