### PR TITLE
Fix typo in xamarin entry point GetDefaultArgon2Parameters

### DIFF
--- a/wrappers/csharp/Native.Xamarin.cs
+++ b/wrappers/csharp/Native.Xamarin.cs
@@ -68,7 +68,7 @@ namespace Devolutions.Cryptography
         [DllImport(LibName, EntryPoint = "GenerateKey", CallingConvention = CallingConvention.Cdecl)]
         internal static extern long GenerateKeyNative(byte[] key, UIntPtr keyLength);
 
-        [DllImport(LibName, EntryPoint = "GetDefaultArgon2ParametersNative", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(LibName, EntryPoint = "GetDefaultArgon2Parameters", CallingConvention = CallingConvention.Cdecl)]
         internal static extern long GetDefaultArgon2ParametersNative(byte[] argon2Parameters, UIntPtr argon2ParametersLength);
 
         [DllImport(LibName, EntryPoint = "GetDefaultArgon2ParametersSize", CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
- Argon2 is currently broken in the xamarin mobile platforms (Mac, Android & iOS)
- Unit tests that I'm working on for the xamarin mobile platforms found the bug.