### PR TITLE
Rename validate_signature() to validate_header()

### DIFF
--- a/devolutions-crypto/src/ffi.rs
+++ b/devolutions-crypto/src/ffi.rs
@@ -672,7 +672,7 @@ pub unsafe extern "C" fn DeriveKey(
 /// # Safety
 /// This method is made to be called by C, so it is therefore unsafe. The caller should make sure it passes the right pointers and sizes.
 #[no_mangle]
-pub unsafe extern "C" fn ValidateSignature(
+pub unsafe extern "C" fn ValidateHeader(
     data: *const u8,
     data_length: usize,
     data_type: u16,
@@ -685,7 +685,7 @@ pub unsafe extern "C" fn ValidateSignature(
 
     match DataType::try_from(data_type) {
         Ok(t) => {
-            if utils::validate_signature(data, t) {
+            if utils::validate_header(data, t) {
                 1
             } else {
                 0

--- a/devolutions-crypto/src/utils.rs
+++ b/devolutions-crypto/src/utils.rs
@@ -59,15 +59,15 @@ pub fn derive_key(key: &[u8], salt: &[u8], iterations: usize, length: usize) -> 
 /// # Example
 /// use devolutions_crypto::DataType;
 /// use devolutions_crypto::ciphertext::{encrypt, CiphertextVersion};
-/// use devolutions_crypto::utils::{generate_key, validate_signature};
+/// use devolutions_crypto::utils::{generate_key, validate_header};
 ///
 /// let key = generate_key(32);
 /// let ciphertext: Vec<u8> = encrypt(b"test", &key, CiphertextVersion::Latest).unwrap().into();
 ///
-/// assert!(validate_signature(&ciphertext, DataType::Ciphertext);
-/// assert!(!validate_signature(&ciphertext, DataType::PasswordHash);
-/// assert!(!validate_signature(&key, DataType::Ciphertext);
-pub fn validate_signature(data: &[u8], data_type: DataType) -> bool {
+/// assert!(validate_header(&ciphertext, DataType::Ciphertext);
+/// assert!(!validate_header(&ciphertext, DataType::PasswordHash);
+/// assert!(!validate_header(&key, DataType::Ciphertext);
+pub fn validate_header(data: &[u8], data_type: DataType) -> bool {
     use super::ciphertext::Ciphertext;
     use super::key::{PrivateKey, PublicKey};
     use super::password_hash::PasswordHash;
@@ -113,7 +113,7 @@ fn test_derive_key() {
 }
 
 #[test]
-fn test_validate_signature() {
+fn test_validate_header() {
     use base64::decode;
 
     let valid_ciphertext = decode("DQwCAAAAAQA=").unwrap();
@@ -122,31 +122,28 @@ fn test_validate_signature() {
     let valid_private_key = decode("DQwBAAEAAQA=").unwrap();
     let valid_public_key = decode("DQwBAAEAAQA=").unwrap();
 
-    assert!(validate_signature(&valid_ciphertext, DataType::Ciphertext));
-    assert!(validate_signature(
+    assert!(validate_header(&valid_ciphertext, DataType::Ciphertext));
+    assert!(validate_header(
         &valid_password_hash,
         DataType::PasswordHash
     ));
-    assert!(validate_signature(&valid_share, DataType::Share));
-    assert!(validate_signature(&valid_private_key, DataType::Key));
-    assert!(validate_signature(&valid_public_key, DataType::Key));
+    assert!(validate_header(&valid_share, DataType::Share));
+    assert!(validate_header(&valid_private_key, DataType::Key));
+    assert!(validate_header(&valid_public_key, DataType::Key));
 
-    assert!(!validate_signature(
-        &valid_ciphertext,
-        DataType::PasswordHash
-    ));
+    assert!(!validate_header(&valid_ciphertext, DataType::PasswordHash));
 
     let invalid_signature = decode("DAwBAAEAAQA=").unwrap();
     let invalid_type = decode("DQwIAAEAAQA=").unwrap();
     let invalid_subtype = decode("DQwBAAgAAQA=").unwrap();
     let invalid_version = decode("DQwBAAEACAA=").unwrap();
 
-    assert!(!validate_signature(&invalid_signature, DataType::Key));
-    assert!(!validate_signature(&invalid_type, DataType::Key));
-    assert!(!validate_signature(&invalid_subtype, DataType::Key));
-    assert!(!validate_signature(&invalid_version, DataType::Key));
+    assert!(!validate_header(&invalid_signature, DataType::Key));
+    assert!(!validate_header(&invalid_type, DataType::Key));
+    assert!(!validate_header(&invalid_subtype, DataType::Key));
+    assert!(!validate_header(&invalid_version, DataType::Key));
 
     let not_long_enough = decode("DQwBAAEAAQ==").unwrap();
 
-    assert!(!validate_signature(&not_long_enough, DataType::Key));
+    assert!(!validate_header(&not_long_enough, DataType::Key));
 }

--- a/devolutions-crypto/src/wasm.rs
+++ b/devolutions-crypto/src/wasm.rs
@@ -276,9 +276,9 @@ pub fn derive_key(
     utils::derive_key(key, &salt, iterations, length)
 }
 
-#[wasm_bindgen(js_name = "validateSignature")]
-pub fn validate_signature(data: &[u8], data_type: DataType) -> bool {
-    utils::validate_signature(data, data_type)
+#[wasm_bindgen(js_name = "validateHeader")]
+pub fn validate_header(data: &[u8], data_type: DataType) -> bool {
+    utils::validate_header(data, data_type)
 }
 
 #[wasm_bindgen]

--- a/wrappers/csharp/Native.Xamarin.cs
+++ b/wrappers/csharp/Native.Xamarin.cs
@@ -89,8 +89,8 @@ namespace Devolutions.Cryptography
         [DllImport(LibName, EntryPoint = "MixKeyExchangeSize", CallingConvention = CallingConvention.Cdecl)]
         internal static extern long MixKeyExchangeSizeNative();
 
-        [DllImport(LibName, EntryPoint = "ValidateSignature", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern long ValidateSignature(byte[] data, UIntPtr dataLength, ushort dataType);
+        [DllImport(LibName, EntryPoint = "ValidateHeader", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern long ValidateHeader(byte[] data, UIntPtr dataLength, ushort dataType);
 
         [DllImport(LibName, EntryPoint = "VerifyPassword", CallingConvention = CallingConvention.Cdecl)]
         internal static extern long VerifyPasswordNative(byte[] password, UIntPtr passwordLength, byte[] hash, UIntPtr hashLength);

--- a/wrappers/csharp/Native.cs
+++ b/wrappers/csharp/Native.cs
@@ -361,14 +361,14 @@ namespace Devolutions.Cryptography
             return Encode86(input, input_length, output, output_length);
         }
 
-        internal static long ValidateSignature(byte[] data, UIntPtr dataLength, ushort dataType)
+        internal static long ValidateHeader(byte[] data, UIntPtr dataLength, ushort dataType)
         {
             if (Environment.Is64BitProcess)
             {
-                return ValidateSignature64(data, dataLength, dataType);
+                return ValidateHeader64(data, dataLength, dataType);
             }
 
-            return ValidateSignature86(data, dataLength, dataType);
+            return ValidateHeader86(data, dataLength, dataType);
         }
 
         internal static long VersionNative(byte[] output, UIntPtr output_length)
@@ -579,11 +579,11 @@ namespace Devolutions.Cryptography
         [DllImport(LibName64, EntryPoint = "MixKeyExchangeSize", CallingConvention = CallingConvention.Cdecl)]
         private static extern long MixKeyExchangeSizeNative64();
 
-        [DllImport(LibName86, EntryPoint = "ValidateSignature", CallingConvention = CallingConvention.Cdecl)]
-        private static extern long ValidateSignature86(byte[] data, UIntPtr dataLength, ushort dataType);
+        [DllImport(LibName86, EntryPoint = "ValidateHeader", CallingConvention = CallingConvention.Cdecl)]
+        private static extern long ValidateHeader86(byte[] data, UIntPtr dataLength, ushort dataType);
 
-        [DllImport(LibName64, EntryPoint = "ValidateSignature", CallingConvention = CallingConvention.Cdecl)]
-        private static extern long ValidateSignature64(byte[] data, UIntPtr dataLength, ushort dataType);
+        [DllImport(LibName64, EntryPoint = "ValidateHeader", CallingConvention = CallingConvention.Cdecl)]
+        private static extern long ValidateHeader64(byte[] data, UIntPtr dataLength, ushort dataType);
 
         [DllImport(LibName86, EntryPoint = "Version", CallingConvention = CallingConvention.Cdecl)]
         private static extern long Version86(byte[] output, UIntPtr output_length);

--- a/wrappers/csharp/Utils.cs
+++ b/wrappers/csharp/Utils.cs
@@ -252,14 +252,26 @@ namespace Devolutions.Cryptography
         /// <param name="data">The buffer to validate.</param>
         /// <param name="type">The data type to validate.</param>
         /// <returns>Returns true if the buffer received matches the data type.</returns>
+        [Obsolete("This method has been deprecated. Use ValidateHeader instead.")]
         public static bool ValidateSignature(byte[] data, DataType type)
+        {
+            return ValidateHeader(data, type);
+        }
+
+        /// <summary>
+        /// Validate that the buffer is from the Devolutions Crypto Library.
+        /// </summary>
+        /// <param name="data">The buffer to validate.</param>
+        /// <param name="type">The data type to validate.</param>
+        /// <returns>Returns true if the buffer received matches the data type.</returns>
+        public static bool ValidateHeader(byte[] data, DataType type)
         {
             if (data == null)
             {
                 return false;
             }
 
-            long result = Native.ValidateSignature(data, (UIntPtr)data.Length, (ushort)type);
+            long result = Native.ValidateHeader(data, (UIntPtr)data.Length, (ushort)type);
 
             if (result < 0)
             {
@@ -271,27 +283,54 @@ namespace Devolutions.Cryptography
 
         /// <summary>
         /// Validate that the base 64 string is from the Devolutions Crypto Library.
-        /// Performance : Use ValidateSignature(byte[], DataType) for more performance if possible.
+        /// Performance : Use ValidateHeader(byte[], DataType) for more performance if possible.
         /// </summary>
         /// <param name="base64">The buffer to validate.</param>
         /// <param name="type">The data type to validate.</param>
         /// <returns>Returns true if the base 64 string received matches the data type.</returns>
+        [Obsolete("This method has been deprecated. Use ValidateHeaderFromBase64 instead.")]
         public static bool ValidateSignatureFromBase64(string base64, DataType type)
+        {
+            return ValidateHeaderFromBase64(base64, type);
+        }
+
+        /// <summary>
+        /// Validate that the base 64 string is from the Devolutions Crypto Library.
+        /// Performance : Use ValidateHeader(byte[], DataType) for more performance if possible.
+        /// </summary>
+        /// <param name="base64">The buffer to validate.</param>
+        /// <param name="type">The data type to validate.</param>
+        /// <returns>Returns true if the base 64 string received matches the data type.</returns>
+        public static bool ValidateHeaderFromBase64(string base64, DataType type)
         {
             byte[] data = DecodeFromBase64(base64);
 
-            return ValidateSignature(data, type);
+            return ValidateHeader(data, type);
         }
 
         /// <summary>
         /// Validate that the stream data is from the Devolutions Crypto Library.
         /// The stream must support both Seeking and Reading.
-        /// Performance : Use ValidateSignature(byte[], DataType) for more performance if possible.
+        /// Performance : Use ValidateHeader(byte[], DataType) for more performance if possible.
         /// </summary>
         /// <param name="stream">The stream to validate.</param>
         /// <param name="type">The data type to validate.</param>
         /// <returns>Returns true if the stream data received matches the data type.</returns>
+        [Obsolete("This method has been deprecated. Use ValidateHeaderFromStream instead.")]
         public static bool ValidateSignatureFromStream(Stream stream, DataType type)
+        {
+            return ValidateHeaderFromStream(stream, type);
+        }
+
+        /// <summary>
+        /// Validate that the stream data is from the Devolutions Crypto Library.
+        /// The stream must support both Seeking and Reading.
+        /// Performance : Use ValidateHeader(byte[], DataType) for more performance if possible.
+        /// </summary>
+        /// <param name="stream">The stream to validate.</param>
+        /// <param name="type">The data type to validate.</param>
+        /// <returns>Returns true if the stream data received matches the data type.</returns>
+        public static bool ValidateHeaderFromStream(Stream stream, DataType type)
         {
             if (stream == null)
             {
@@ -323,7 +362,7 @@ namespace Devolutions.Cryptography
                     return false;
                 }
 
-                return ValidateSignature(buffer, type);
+                return ValidateHeader(buffer, type);
             }
             catch (DevolutionsCryptoException)
             {

--- a/wrappers/csharp/unit-tests/TestManaged.cs
+++ b/wrappers/csharp/unit-tests/TestManaged.cs
@@ -142,7 +142,7 @@ namespace xamarin_ios
         {
             byte[] base64DataAsUtf8ByteArray = Utils.StringToUtf8ByteArray(TestData.Base64TestData2);
             byte[] encryptResult = Managed.Encrypt(base64DataAsUtf8ByteArray, TestData.BytesTestKey);
-            Assert.IsTrue(Utils.ValidateSignature(encryptResult, DataType.Cipher));
+            Assert.IsTrue(Utils.ValidateHeader(encryptResult, DataType.Cipher));
 
             byte[] decryptResult = Managed.Decrypt(encryptResult, TestData.BytesTestKey);
             var decryptResultAsUtf8String = Utils.ByteArrayToUtf8String(decryptResult);
@@ -164,7 +164,7 @@ namespace xamarin_ios
         public void EncryptBase64WithPassword()
         {
             byte[] encryptedData = Managed.EncryptBase64WithPassword(TestData.Base64TestData, TestData.TestPassword);
-            Assert.IsTrue(Utils.ValidateSignature(encryptedData, DataType.Cipher));
+            Assert.IsTrue(Utils.ValidateHeader(encryptedData, DataType.Cipher));
             byte[] decryptResult = Managed.DecryptWithPassword(encryptedData, TestData.TestPassword);
             string decryptResultString = Utils.ByteArrayToUtf8String(decryptResult);
             Assert.AreEqual(decryptResultString, TestData.StringTestData);

--- a/wrappers/csharp/unit-tests/TestUtils.cs
+++ b/wrappers/csharp/unit-tests/TestUtils.cs
@@ -98,8 +98,8 @@ namespace xamarin_ios
 
             byte[] encryptResult = Managed.Encrypt(dataToEncrypt, password);
 
-            Assert.IsFalse(Utils.ValidateSignature(dataToEncrypt, DataType.Cipher));
-            Assert.IsTrue(Utils.ValidateSignature(encryptResult, DataType.Cipher));
+            Assert.IsFalse(Utils.ValidateHeader(dataToEncrypt, DataType.Cipher));
+            Assert.IsTrue(Utils.ValidateHeader(encryptResult, DataType.Cipher));
         }
 
         [TestMethod]
@@ -107,7 +107,7 @@ namespace xamarin_ios
         {
             Stream stream = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
 
-            bool validationResult = Utils.ValidateSignatureFromStream(stream, DataType.Cipher);
+            bool validationResult = Utils.ValidateHeaderFromStream(stream, DataType.Cipher);
 
             Assert.AreEqual(validationResult, false);
         }
@@ -123,7 +123,7 @@ namespace xamarin_ios
 
             try
             {
-                bool validationResult = Utils.ValidateSignatureFromStream(stream, DataType.Cipher);
+                bool validationResult = Utils.ValidateHeaderFromStream(stream, DataType.Cipher);
             }
             catch (DevolutionsCryptoException ex)
             {
@@ -143,7 +143,7 @@ namespace xamarin_ios
 
             stream.Position = 12;
 
-            bool validationResult = Utils.ValidateSignatureFromStream(stream, DataType.Cipher);
+            bool validationResult = Utils.ValidateHeaderFromStream(stream, DataType.Cipher);
 
             Assert.AreEqual(stream.Position, 12);
             Assert.AreEqual(validationResult, false);
@@ -158,7 +158,7 @@ namespace xamarin_ios
 
             try
             {
-                bool validationResult = Utils.ValidateSignatureFromStream(stream, DataType.Cipher);
+                bool validationResult = Utils.ValidateHeaderFromStream(stream, DataType.Cipher);
             }
             catch (DevolutionsCryptoException ex)
             {
@@ -177,7 +177,7 @@ namespace xamarin_ios
 
             try
             {
-                bool validationResult = Utils.ValidateSignatureFromStream(stream, DataType.Cipher);
+                bool validationResult = Utils.ValidateHeaderFromStream(stream, DataType.Cipher);
             }
             catch (DevolutionsCryptoException ex)
             {
@@ -193,7 +193,7 @@ namespace xamarin_ios
         {
             Stream stream = new MemoryStream(TestData.EncryptedData);
 
-            bool validationResult = Utils.ValidateSignatureFromStream(stream, DataType.Cipher);
+            bool validationResult = Utils.ValidateHeaderFromStream(stream, DataType.Cipher);
 
             Assert.AreEqual(validationResult, true);
         }

--- a/wrappers/wasm/tests/tests/utils.ts
+++ b/wrappers/wasm/tests/tests/utils.ts
@@ -1,4 +1,4 @@
-import { generateKey, deriveKey, validateSignature, base64encode, base64decode, DataType } from 'devolutions-crypto'
+import { generateKey, deriveKey, validateHeader, base64encode, base64decode, DataType } from 'devolutions-crypto'
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
 
@@ -65,31 +65,31 @@ describe('validateSignature', () => {
     const validPrivateKey: Uint8Array = base64decode('DQwBAAEAAQA=')
     const validPublicKey: Uint8Array = base64decode('DQwBAAEAAQA=')
 
-    expect(validateSignature(validCiphertext, DataType.Ciphertext)).to.eql(true)
-    expect(validateSignature(validPasswordHash, DataType.PasswordHash)).to.eql(true)
-    expect(validateSignature(validShare, DataType.Share)).to.eql(true)
-    expect(validateSignature(validPrivateKey, DataType.Key)).to.eql(true)
-    expect(validateSignature(validPublicKey, DataType.Key)).to.eql(true)
+    expect(validateHeader(validCiphertext, DataType.Ciphertext)).to.eql(true)
+    expect(validateHeader(validPasswordHash, DataType.PasswordHash)).to.eql(true)
+    expect(validateHeader(validShare, DataType.Share)).to.eql(true)
+    expect(validateHeader(validPrivateKey, DataType.Key)).to.eql(true)
+    expect(validateHeader(validPublicKey, DataType.Key)).to.eql(true)
   })
 
   it('should return false', () => {
     const validCiphertext: Uint8Array = base64decode('DQwCAAAAAQA=')
 
-    expect(validateSignature(validCiphertext, DataType.PasswordHash)).to.eql(false)
+    expect(validateHeader(validCiphertext, DataType.PasswordHash)).to.eql(false)
 
     const invalidSignature: Uint8Array = base64decode('DAwBAAEAAQA=')
     const invalidType: Uint8Array = base64decode('DQwIAAEAAQA=')
     const invalidSubtype: Uint8Array = base64decode('DQwBAAgAAQA=')
     const invalidVersion: Uint8Array = base64decode('DQwBAAEACAA=')
 
-    expect(validateSignature(invalidSignature, DataType.Key)).to.eql(false)
-    expect(validateSignature(invalidType, DataType.Key)).to.eql(false)
-    expect(validateSignature(invalidSubtype, DataType.Key)).to.eql(false)
-    expect(validateSignature(invalidVersion, DataType.Key)).to.eql(false)
+    expect(validateHeader(invalidSignature, DataType.Key)).to.eql(false)
+    expect(validateHeader(invalidType, DataType.Key)).to.eql(false)
+    expect(validateHeader(invalidSubtype, DataType.Key)).to.eql(false)
+    expect(validateHeader(invalidVersion, DataType.Key)).to.eql(false)
 
     const notLongEnough: Uint8Array = base64decode('DQwBAAEAAQ==')
 
-    expect(validateSignature(notLongEnough, DataType.Key)).to.eql(false)
+    expect(validateHeader(notLongEnough, DataType.Key)).to.eql(false)
   })
 })
 


### PR DESCRIPTION
This will avoid confusion with hash/signature later on.