### PR TITLE
Fix Clippy Warnings

### DIFF
--- a/devolutions-crypto/Cargo.lock
+++ b/devolutions-crypto/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "devolutions-crypto"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "aead",
  "aes",

--- a/devolutions-crypto/src/error.rs
+++ b/devolutions-crypto/src/error.rs
@@ -1,6 +1,5 @@
 //! Possible errors in the library.
 
-use std;
 use std::fmt;
 
 #[cfg(target_arch = "wasm32")]
@@ -11,7 +10,6 @@ use strum_macros::IntoStaticStr;
 use block_modes::{BlockModeError, InvalidKeyIvLength};
 use hmac::crypto_mac::InvalidKeyLength;
 use hmac::crypto_mac::MacError;
-use rand;
 
 /// This crate's error type.
 #[derive(Debug, IntoStaticStr)]

--- a/devolutions-crypto/src/utils.rs
+++ b/devolutions-crypto/src/utils.rs
@@ -1,6 +1,5 @@
 //! Module for utils that does not use any of the Devolutions custom data types.
 
-use base64;
 use hmac::Hmac;
 use pbkdf2::pbkdf2;
 use rand::{rngs::OsRng, RngCore};


### PR DESCRIPTION
New warnings has been introduced in clippy in Rust 1.43.

This PR fixes them.