### PR TITLE
devolutions-crypto-wayk: small key exchange api update

### DIFF
--- a/devolutions-crypto-wayk/Cargo.lock
+++ b/devolutions-crypto-wayk/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "devolutions-crypto-wayk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "block-padding",

--- a/devolutions-crypto-wayk/Cargo.toml
+++ b/devolutions-crypto-wayk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devolutions-crypto-wayk"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Benoît CORTIER <benoit.cortier@fried-world.eu>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/devolutions-crypto-wayk/src/bastion/key_exchange.rs
+++ b/devolutions-crypto-wayk/src/bastion/key_exchange.rs
@@ -6,6 +6,8 @@ use zeroize::{Zeroize, Zeroizing};
 pub use x25519_dalek::PublicKey;
 
 /// Wraps shared secret produced by key exchange
+#[derive(Zeroize)]
+#[zeroize(drop)]
 pub struct SharedSecret([u8; 32]);
 
 impl SharedSecret {
@@ -28,21 +30,9 @@ impl SharedSecret {
     }
 }
 
-impl Zeroize for SharedSecret {
-    fn zeroize(&mut self) {
-        self.0.zeroize();
-    }
-}
-
-impl Drop for SharedSecret {
-    fn drop(&mut self) {
-        self.zeroize();
-    }
-}
-
 impl From<[u8; 32]> for SharedSecret {
-    fn from(array: [u8; 32]) -> Self {
-        Self(array)
+    fn from(bytes: [u8; 32]) -> Self {
+        Self::from_bytes(bytes)
     }
 }
 


### PR DESCRIPTION
Remove dalek's `SharedSecret` struct re-export and use a custom one instead.

# Motivation

dalek's `SharedSecret` can't be constructed by user, but we need to in Wayk Bastion. I could just return and directly use the underlying `[u8; 32]` instead of using another type but I prefer not to so that user can't forget to zeroize critical data and it's harder to misuse involuntary since `encrypt_key` and `decrypt_key` takes a `SharedSecret` explicitly.