### PR TITLE
chore: fix ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
   native_build_macos:
     needs: [rust_code_format, setup_config]
-    runs-on: "macos-11"
+    runs-on: "macos-12"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -61,7 +61,7 @@ jobs:
 
   native_build_ios:
     needs: [rust_code_format, setup_config]
-    runs-on: "macos-11"
+    runs-on: "macos-12"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -102,7 +102,7 @@ jobs:
 
   nugets_macos:
     needs: [native_build_macos, native_build_ios, native_build_linux, csharp_code_format, setup_config]
-    runs-on: "macos-11"
+    runs-on: "macos-12"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -125,7 +125,7 @@ jobs:
   #### WEB ASSEMBLY TEST ####
   webassembly_test:
     needs: webassembly_build
-    runs-on: "macos-11"
+    runs-on: "macos-12"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -146,7 +146,7 @@ jobs:
 
   tests_nuget_macos:
     needs: [nugets_macos, nugets_windows, setup_config]
-    runs-on: "macos-11"
+    runs-on: "macos-12"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -157,7 +157,7 @@ jobs:
 
   tests_nuget_ios:
     needs: [nugets_macos, setup_config]
-    runs-on: "macos-11"
+    runs-on: "macos-12"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -187,7 +187,7 @@ jobs:
 
   tests_ios_integration:
     needs: [tests_nuget_ios, setup_config]
-    runs-on: "macos-11"
+    runs-on: "macos-12"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -223,7 +223,7 @@ jobs:
       - uses: ./.github/workflows/python/build/linux
 
   build_python_macos:
-    runs-on: "macos-11"
+    runs-on: "macos-12"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -250,7 +250,7 @@ jobs:
 
   test_python_macos:
     needs: build_python_macos
-    runs-on: "macos-11"
+    runs-on: "macos-12"
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/tests/python/macos

--- a/.github/workflows/nugets/nugets-macos/action.yml
+++ b/.github/workflows/nugets/nugets-macos/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
       run: sudo nuget update -self
 
-    # dotnet restore fails on macos-11
+    # dotnet restore fails on macos-12
     # https://github.com/actions/virtual-environments/issues/5768
     - name: Nuget workaround
       shell: bash

--- a/.github/workflows/tests/csharp/android/action.yml
+++ b/.github/workflows/tests/csharp/android/action.yml
@@ -25,7 +25,7 @@ runs:
 
     - name: Installing SDK Android-33 x86_64
       shell: bash
-      run: /Users/runner/Library/Android/sdk/tools/bin/sdkmanager --install "system-images;android-33;google_apis;x86_64"
+      run: echo "y" | /Users/runner/Library/Android/sdk/tools/bin/sdkmanager --install "system-images;android-33;google_apis;x86_64"
       
     - name: Creating Android device
       shell: bash

--- a/.github/workflows/tests/csharp/macos/action.yml
+++ b/.github/workflows/tests/csharp/macos/action.yml
@@ -31,6 +31,15 @@ runs:
       shell: bash
       run: python3 unit-tests.py -p mac
 
+# Install latest Xamarin.Mac to fix issue with the one packaged in the runner. (mac modern only)
+# ld: Framework not found CHIP
+# https://github.com/actions/runner-images/issues/7058
+    - name: Install Latest Xamarin Mac
+      shell: bash
+      run : |
+        wget https://download.visualstudio.microsoft.com/download/pr/1d39655e-c5e8-4af9-93cd-4174278a0895/7976384b6c703a55a4c9d5f1c640e0b1/xamarin.mac-9.1.0.2.pkg
+        sudo installer -pkg xamarin.mac-9.1.0.2.pkg -target /
+    
     - name: Unit tests XAMARIN-MAC-MODERN
       working-directory: ./wrappers/csharp/tests/unit-tests/nugets
       shell: bash

--- a/.github/workflows/tests/python/linux/action.yml
+++ b/.github/workflows/tests/python/linux/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Install wheel
       working-directory: ./wheels
       shell: bash
-      run: pip install --find-links="./" devolutions_crypto
+      run: pip install --no-index --find-links="./" devolutions_crypto
 
     - name: Run 3.10 tests
       working-directory: ./wrappers/python 
@@ -47,7 +47,7 @@ runs:
     - name: Install wheel
       working-directory: ./wheels
       shell: bash
-      run: pip install --find-links="./" devolutions_crypto
+      run: pip install --no-index --find-links="./" devolutions_crypto
 
     - name: Run 3.9 tests
       working-directory: ./wrappers/python 
@@ -70,7 +70,7 @@ runs:
     - name: Install wheel
       working-directory: ./wheels
       shell: bash
-      run: pip install --find-links="./" devolutions_crypto
+      run: pip install --no-index --find-links="./" devolutions_crypto
 
     - name: Run 3.8 tests
       working-directory: ./wrappers/python 
@@ -93,7 +93,7 @@ runs:
     - name: Install wheel
       working-directory: ./wheels
       shell: bash
-      run: pip install --find-links="./" devolutions_crypto
+      run: pip install --no-index --find-links="./" devolutions_crypto
 
     - name: Run 3.7 tests
       working-directory: ./wrappers/python 

--- a/.github/workflows/tests/python/macos/action.yml
+++ b/.github/workflows/tests/python/macos/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Install wheel
       working-directory: ./wheels
       shell: bash
-      run: pip install --find-links="./" devolutions_crypto
+      run: pip install --no-index --find-links="./" devolutions_crypto
 
     - name: Run tests
       working-directory: ./wrappers/python

--- a/.github/workflows/tests/python/windows/action.yml
+++ b/.github/workflows/tests/python/windows/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Install wheel
       working-directory: ./wheels
       shell: bash
-      run: pip install --find-links="./" devolutions_crypto
+      run: pip install --no-index --find-links="./" devolutions_crypto
 
     - name: Run tests
       working-directory: ./wrappers/python/tests/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ target/
 bin
 obj
 .angular
+node_modules

--- a/wrappers/csharp/tests/unit-tests/nugets/unit-tests.py
+++ b/wrappers/csharp/tests/unit-tests/nugets/unit-tests.py
@@ -239,16 +239,6 @@ def test_mac_full(script_dir, version, args):
         exit(1)
 
 def test_mac_modern(script_dir, version, args):
-    # Patch submodule for pipeline (MSBuildExtensionsPath is wrong)
-    print("patching submodule")
-    filedata = ""
-    with open('./xamarin-mac-modern/guiunit/src/framework/GuiUnit_xammac_mobile.csproj','r') as file:
-        filedata = file.read()
-        filedata = filedata.replace("""<Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />""", """<Import Project="/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/msbuild/Xamarin.Mac.CSharp.targets" />""")
-
-    with open('./xamarin-mac-modern/guiunit/src/framework/GuiUnit_xammac_mobile.csproj','w') as file:
-        file.write(filedata)
-
     print("Nuget Cache Clear")
     print("==========================================================================")    
     

--- a/wrappers/csharp/tests/unit-tests/nugets/xamarin-mac-modern/Main.cs
+++ b/wrappers/csharp/tests/unit-tests/nugets/xamarin-mac-modern/Main.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Reflection;
 using AppKit;
+using NUnitLite;
 
 namespace xamarinmacmodern
 {
@@ -8,13 +9,7 @@ namespace xamarinmacmodern
     {
         static void Main(string[] args)
         {
-            string resultFile = Path.Combine(Assembly.GetExecutingAssembly().Location.Split("bin/Debug")[0], "TestResult.xml");
-
-            string[] testArgs = new string[] { Assembly.GetExecutingAssembly().Location, "-noheader", "-xml:" + resultFile };
-            GuiUnit.TestRunner.Main(testArgs);
-
-            //NSApplication.Init();
-            //NSApplication.Main(args);
+            new AutoRun(Assembly.GetExecutingAssembly()).Execute(new string[] { "--out=../../../../../TestResult.xml"});
         }
     }
 }

--- a/wrappers/csharp/tests/unit-tests/nugets/xamarin-mac-modern/xamarin-mac-modern.csproj
+++ b/wrappers/csharp/tests/unit-tests/nugets/xamarin-mac-modern/xamarin-mac-modern.csproj
@@ -53,6 +53,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Devolutions.Crypto.Mac.Modern" Version="*" />
+    <PackageReference Include="NUnitLite">
+      <Version>3.13.3</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
@@ -111,10 +114,6 @@
     <InterfaceDefinition Include="Main.storyboard" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="guiunit\src\framework\GuiUnit_xammac_mobile.csproj">
-      <Project>{EACFD119-769E-4E6C-89B7-A6CE3757C431}</Project>
-      <Name>GuiUnit_xammac_mobile</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/msbuild/Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/wrappers/csharp/tests/unit-tests/nugets/xamarin-mac-modern/xamarin-mac-modern.sln
+++ b/wrappers/csharp/tests/unit-tests/nugets/xamarin-mac-modern/xamarin-mac-modern.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xamarin-mac-modern", "xamarin-mac-modern.csproj", "{C014C599-8BEC-48F8-9860-02466A19F077}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GuiUnit_xammac_mobile", "guiunit\src\framework\GuiUnit_xammac_mobile.csproj", "{EACFD119-769E-4E6C-89B7-A6CE3757C431}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
- Switch to macOS 12 runners to fix stalling iOS unit tests.
   - I had to install the latest Xamarin.Mac to fix build issue with Xamarin Mac Modern. For some reason the issue is closed.
    https://github.com/actions/runner-images/issues/7058
- It is now required to accept the Android SDK license.
- Replaced guiunit with nunitlite.
- Add --noindex to pip install to force use local package.
- GeneratePackage.py script now works locally on macOS.
