### PR TITLE
Rollback the runner for Linux native builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   #### NATIVE BUILD ####
   native_build_linux:
     needs: [rust_code_format, setup_config]
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04" # Ensure we build with the minimum supported sysroot
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/native/native-build-linux


### PR DESCRIPTION
At some point in late 2022; the `ubuntu-latest` tag in GitHub Actions started to point at Ubuntu 22.04.

Libraries built after this point won't load on older Ubuntu versions - the glibc dependency has moved to 2.33, but Ubuntu 20.04 (which is an LTS) only has 2.31.

We should explicitly build on the tag we want to support.