### PR TITLE
Split android unit-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
       - run: git lfs pull
       - uses: ./.github/workflows/tests/csharp/linux
 
-  tests_nuget_android:
+  tests_nuget_android_build:
     needs: [nugets_macos, setup_config]
     runs-on: "macos-12"
     steps:
@@ -181,7 +181,17 @@ jobs:
         with:
           lfs: true
       - run: git lfs pull
-      - uses: ./.github/workflows/tests/csharp/android
+      - uses: ./.github/workflows/tests/csharp/android-build
+
+  tests_nuget_android_run:
+    needs: [tests_nuget_android_build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+      - run: git lfs pull
+      - uses: ./.github/workflows/tests/csharp/android-run
 
   tests_ios_integration:
     needs: [tests_nuget_ios, setup_config]

--- a/.github/workflows/tests/csharp/android-build/action.yml
+++ b/.github/workflows/tests/csharp/android-build/action.yml
@@ -1,0 +1,30 @@
+name: Build Unit Tests Android Nuget
+description: This tests the Android nuget package.
+runs:
+  using: composite
+  steps:
+    - name: Download Config
+      uses: actions/download-artifact@v3
+      with:
+        name: config.txt
+        path: ./wrappers/csharp
+
+    - name: Download Native Libs
+      uses: actions/download-artifact@v3
+      with:
+        name: nugets
+        path: ./wrappers/csharp/tests/unit-tests/nugets/Nugets
+
+    - name: Update Nuget
+      shell: bash
+      run: sudo nuget update -self
+
+    - name: Build Unit tests XAMARIN-ANDROID
+      working-directory: ./wrappers/csharp/tests/unit-tests/nugets
+      shell: bash
+      run: python3 unit-tests.py -p android -a build
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: unit-test-build
+        path: ./wrappers/csharp/tests/unit-tests/nugets/xamarin-android/bin/Debug/*.apk

--- a/.github/workflows/tests/csharp/android-run/action.yml
+++ b/.github/workflows/tests/csharp/android-run/action.yml
@@ -1,4 +1,4 @@
-name: Unit Tests Android Nuget
+name: Run Unit Tests Android Nuget
 description: This tests the Android nuget package.
 runs:
   using: composite
@@ -15,24 +15,45 @@ runs:
         name: nugets
         path: ./wrappers/csharp/tests/unit-tests/nugets/Nugets
 
+    - name: Download Unit-test-builds
+      uses: actions/download-artifact@v3
+      with:
+        name: unit-test-build
+        path: ./wrappers/csharp/tests/unit-tests/nugets/xamarin-android/bin/Debug/
+
     - name: Update Nuget
       shell: bash
       run: sudo nuget update -self
+
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '8'
+
+    - name:  Setting up PATH environment variable
+      shell: bash
+      run: |
+        echo "/usr/local/lib/android/sdk/platform-tools/" >> $GITHUB_PATH
+        echo "/usr/local/lib/android/sdk/tools/bin/" >> $GITHUB_PATH
+        echo "/usr/local/lib/android/sdk/emulator/" >> $GITHUB_PATH
 
     - name: Starting ADB Server
       shell: bash
       run: adb start-server
 
-    - name: Installing SDK Android-33 x86_64
+    - name: Install Pulseaudio # required by qemu
       shell: bash
-      run: echo "y" | /Users/runner/Library/Android/sdk/tools/bin/sdkmanager --install "system-images;android-33;google_apis;x86_64"
+      run: sudo apt-get install pulseaudio
+
+    - name: Installing SDK Android-34 x86_64
+      shell: bash
+      run: echo "y" | sdkmanager --install "system-images;android-34;google_apis;x86_64"
 
     - name: Creating Android device
       shell: bash
-      run: echo "no" | /Users/runner/Library/Android/sdk/tools/bin/avdmanager create avd -n test_emulator -k "system-images;android-33;google_apis;x86_64"
+      run: echo "no" | avdmanager create avd -n test_emulator -k "system-images;android-34;google_apis;x86_64"
 
     - name: Starting emulator
-      working-directory: /Users/runner/Library/Android/sdk/tools/
       shell: bash
       run: emulator @test_emulator &
 
@@ -62,4 +83,4 @@ runs:
     - name: Unit tests XAMARIN-ANDROID
       working-directory: ./wrappers/csharp/tests/unit-tests/nugets
       shell: bash
-      run: python3 unit-tests.py -p android
+      run: python3 unit-tests.py -p android -a run

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ wrappers/csharp/dotnet-core/bin
 wrappers/csharp/tests/unit-tests/manual/dotnet-framework/bin/
 wrappers/csharp/tests/unit-tests/manual/dotnet-core/bin/
 target/
+hooks/
 **/*.rs.bk
 .vscode
 bin


### PR DESCRIPTION
- MacOS runner performance is abysmal since a few months. The Android Emulator always fails to boot.
- Use only the macOS runner to build the APK then run the tests on Linux.