### PR TITLE
Disable android tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,16 +172,19 @@ jobs:
           lfs: true
       - run: git lfs pull
       - uses: ./.github/workflows/tests/csharp/linux
-
-  tests_nuget_android:
-    needs: [nugets_macos, setup_config]
-    runs-on: "macos-12"
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          lfs: true
-      - run: git lfs pull
-      - uses: ./.github/workflows/tests/csharp/android
+  
+  #=================================================
+  # Disabled for now, Android Emulator doesn't boot. - mmorrissette 2024-02-21
+  #================================================= 
+  #tests_nuget_android:
+  #  needs: [nugets_macos, setup_config]
+  #  runs-on: "macos-12"
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #      with:
+  #        lfs: true
+  #    - run: git lfs pull
+  #    - uses: ./.github/workflows/tests/csharp/android
 
   tests_ios_integration:
     needs: [tests_nuget_ios, setup_config]

--- a/wrappers/csharp/nuget/Android/Devolutions.Crypto.Android/Devolutions.Crypto.Android/Devolutions.Crypto.Android.csproj
+++ b/wrappers/csharp/nuget/Android/Devolutions.Crypto.Android/Devolutions.Crypto.Android/Devolutions.Crypto.Android.csproj
@@ -15,7 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
The emulator no longer boots for some unknown reasons so we are disabling it temporarily. 