### PR TITLE
fix: Fix a breaking change introduced in 0.9.0

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -209,7 +209,8 @@ const BASE64_CONFIG_NO_PAD: GeneralPurposeConfig = GeneralPurposeConfig::new()
     .with_decode_allow_trailing_bits(true);
 
 const DEVO_BASE64: GeneralPurpose = GeneralPurpose::new(&alphabet::STANDARD, BASE64_CONFIG);
-const DEVO_BASE64_URLSAFE_NOPAD: GeneralPurpose = GeneralPurpose::new(&alphabet::URL_SAFE, BASE64_CONFIG_NO_PAD);
+const DEVO_BASE64_URLSAFE_NOPAD: GeneralPurpose =
+    GeneralPurpose::new(&alphabet::URL_SAFE, BASE64_CONFIG_NO_PAD);
 
 #[test]
 fn test_constant_time_equals() {


### PR DESCRIPTION
Introduced in this PR bumping base64 crate to > 0.13
https://github.com/Devolutions/devolutions-crypto/commit/48effcb33ae9421f833515aa0d7ac05ff144a324#diff-c6770f030cafad29e47557ce009babbfd097c5a5638d71cd4065ee081a6e8525R181

The new default engines since 0.14 are not ecquivalent to the previous defaults;
they used to accept both padded and non-padded when deserializing (while of course padding or not according to the configuration), but the new default engines throw an error when the padding is different than expected.
https://github.com/marshallpierce/rust-base64/issues/206
https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md#padding