### PR TITLE
fix(release): Fix lfs dylib & wrong aar name

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 *.exe filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
-*.dylib filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/kotlin/kotlin-linux/action.yml
+++ b/.github/workflows/kotlin/kotlin-linux/action.yml
@@ -119,6 +119,8 @@ runs:
         ./gradlew build
         ./gradlew generatePomFileForMavenPublication
 
+        mv ./lib/build/outputs/aar/lib-release.aar ./lib/build/outputs/aar/lib.aar
+
     - name: Set version in pom file
       shell: bash
       working-directory: ./wrappers/

--- a/.github/workflows/release-others.yml
+++ b/.github/workflows/release-others.yml
@@ -147,7 +147,7 @@ jobs:
         cloudsmith push maven devolutions/maven-public devolutions-crypto-maven-jvm/libs/lib.jar \
           --pom-file=devolutions-crypto-maven-jvm/publications/maven/pom-default.xml \
 
-        cloudsmith push maven devolutions/maven-public devolutions-crypto-maven-android/outputs/aar/lib-release.aar \
+        cloudsmith push maven devolutions/maven-public devolutions-crypto-maven-android/outputs/aar/lib.aar \
         --pom-file=devolutions-crypto-maven-android/publications/mavenAndroid/pom-default.xml \
       env:
         CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}


### PR DESCRIPTION
Fix dylib being transformed to lfs which make cocoa pod unusable.
Fix wrong aar name preventing android studio from finding it.