### PR TITLE
ci(PyPI): migrate to trusted publishing

### DIFF
--- a/.github/workflows/release-others.yml
+++ b/.github/workflows/release-others.yml
@@ -158,19 +158,25 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.DEVOLUTIONSBOT_WRITE_TOKEN }}
 
-    - name: Publish Python
+    - name: Publish Python to TestPyPI (Dry Run)
+      if: ${{ inputs.publish_python && inputs.publish_dry_run }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        packages-dir: ./devolutions-crypto-wheels/
+        verbose: true
+
+    - name: Publish Python to PyPI
+      if: ${{ inputs.publish_python && !inputs.publish_dry_run }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: ./devolutions-crypto-wheels/
+
+    - name: Tag Python Release
       if: ${{ inputs.publish_python && !inputs.publish_dry_run }}
       run: |
-        pip install twine
-
-        if [ '${{ inputs.publish_dry_run }}' == 'true' ]; then
-          twine upload --verbose  --repository testpypi -u "__token__" -p ${{ secrets.PYPI_TEST_API_KEY }} ./devolutions-crypto-wheels/*
-        else
-          twine upload --verbose -u "__token__" -p ${{ secrets.PYPI_API_KEY }} ./devolutions-crypto-wheels/*
-
-          git tag "python-v${{ steps.version.outputs.version_native }}"
-          git push origin "python-v${{ steps.version.outputs.version_native }}"
-        fi
+        git tag "python-v${{ steps.version.outputs.version_native }}"
+        git push origin "python-v${{ steps.version.outputs.version_native }}"
 
     - name: Publish Kotlin to Cloudsmith
       if: ${{ inputs.publish_kotlin && !inputs.publish_dry_run }}


### PR DESCRIPTION
- Replace twine with pypa/gh-action-pypi-publish@release/v1
- Use OIDC authentication instead of API tokens
- Support both PyPI (production) and TestPyPI (dry-run)
- Separate publish and tagging steps for clarity

Task: DEVOPS-3951