### PR TITLE
test(fuzz): add coverage for derive_encrypt and key_derivation parsing

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -168,3 +168,15 @@ path = "fuzz_targets/key/generate_keypair.rs"
 [[bin]]
 name = "constant_time_equals"
 path = "fuzz_targets/utils/constant_time_equals.rs"
+
+[[bin]]
+name = "kdf_encrypted_data_deserialization"
+path = "fuzz_targets/derive_encrypt/kdf_encrypted_data_deserialization.rs"
+
+[[bin]]
+name = "derivation_parameters_deserialization"
+path = "fuzz_targets/key_derivation/derivation_parameters_deserialization.rs"
+
+[[bin]]
+name = "decrypt_with_password"
+path = "fuzz_targets/derive_encrypt/decrypt_with_password.rs"

--- a/fuzz/fuzz_targets/derive_encrypt/decrypt_with_password.rs
+++ b/fuzz/fuzz_targets/derive_encrypt/decrypt_with_password.rs
@@ -1,0 +1,63 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use devolutions_crypto::derive_encrypt::encrypt_with_password_and_aad;
+use devolutions_crypto::key_derivation::Argon2;
+use devolutions_crypto::{Argon2Parameters, CiphertextVersion};
+
+#[derive(Arbitrary, Clone, Debug)]
+struct Input {
+    data: Vec<u8>,
+    password: Vec<u8>,
+    aad: Vec<u8>,
+    decrypt_password: Vec<u8>,
+    decrypt_aad: Vec<u8>,
+    length: u32,
+    lanes: u32,
+    memory: u32,
+    iterations: u32,
+    salt: Vec<u8>,
+}
+
+fuzz_target!(|input: Input| {
+    // Clamp Argon2 parameters to keep key derivation cheap enough for fuzzing.
+    let length = input.length.clamp(1, 128);
+    let lanes = input.lanes.clamp(1, 16);
+    let memory = input.memory.clamp(8, 65536);
+    let iterations = input.iterations.clamp(1, 10);
+
+    // Use only small salts for fuzzing performance.
+    let salt = if input.salt.len() > 64 {
+        &input.salt[..64]
+    } else if input.salt.is_empty() {
+        &[0u8; 8][..]
+    } else {
+        &input.salt[..]
+    };
+
+    let parameters = Argon2Parameters::builder()
+        .length(length)
+        .lanes(lanes)
+        .memory(memory)
+        .iterations(iterations)
+        .salt(salt.to_vec())
+        .build();
+
+    let derivation_parameters = Argon2::with_params(parameters).parameters();
+
+    let blob = match encrypt_with_password_and_aad(
+        &input.data,
+        &input.password,
+        &input.aad,
+        derivation_parameters,
+        CiphertextVersion::Latest,
+    ) {
+        Ok(b) => b,
+        Err(_) => return,
+    };
+
+    // Exercise the decrypt path with both the correct and a fuzzed password/AAD.
+    let _ = blob.decrypt_with_password_and_aad(&input.password, &input.aad);
+    let _ = blob.decrypt_with_password_and_aad(&input.decrypt_password, &input.decrypt_aad);
+});

--- a/fuzz/fuzz_targets/derive_encrypt/decrypt_with_password.rs
+++ b/fuzz/fuzz_targets/derive_encrypt/decrypt_with_password.rs
@@ -13,7 +13,6 @@ struct Input {
     aad: Vec<u8>,
     decrypt_password: Vec<u8>,
     decrypt_aad: Vec<u8>,
-    length: u32,
     lanes: u32,
     memory: u32,
     iterations: u32,
@@ -22,7 +21,10 @@ struct Input {
 
 fuzz_target!(|input: Input| {
     // Clamp Argon2 parameters to keep key derivation cheap enough for fuzzing.
-    let length = input.length.clamp(1, 128);
+    // The derived key feeds a SecretKey, which requires exactly 32 bytes; any
+    // other length would fail in encrypt_with_password_and_aad before reaching
+    // the decrypt path. Arbitrary output lengths are covered by derive_key_argon2.
+    let length = 32;
     let lanes = input.lanes.clamp(1, 16);
     let memory = input.memory.clamp(8, 65536);
     let iterations = input.iterations.clamp(1, 10);

--- a/fuzz/fuzz_targets/derive_encrypt/kdf_encrypted_data_deserialization.rs
+++ b/fuzz/fuzz_targets/derive_encrypt/kdf_encrypted_data_deserialization.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use devolutions_crypto::derive_encrypt::KdfEncryptedData;
+
+use std::convert::TryFrom;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = KdfEncryptedData::try_from(data);
+});

--- a/fuzz/fuzz_targets/key_derivation/derivation_parameters_deserialization.rs
+++ b/fuzz/fuzz_targets/key_derivation/derivation_parameters_deserialization.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use devolutions_crypto::key_derivation::DerivationParameters;
+
+use std::convert::TryFrom;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = DerivationParameters::try_from(data);
+});


### PR DESCRIPTION
## Summary

Adds fuzz coverage for three untrusted-byte paths in the `derive_encrypt` and `key_derivation` modules that previously had no fuzz target.

The `derive_encrypt` module was entirely unfuzzed, and `DerivationParameters` deserialization — another public `TryFrom<&[u8]>` parser of attacker-controllable bytes — had no coverage.

## New targets

| Target | Path covered |
|---|---|
| `kdf_encrypted_data_deserialization` | `KdfEncryptedData::try_from(&[u8])` |
| `derivation_parameters_deserialization` | `DerivationParameters::try_from(&[u8])` |
| `decrypt_with_password` | `encrypt_with_password_and_aad` → `decrypt_with_password_and_aad` round-trip |

For `decrypt_with_password`, the Argon2 parameters are clamped (length/lanes/memory/iterations + small salt, same approach as the existing `derive_key_argon2` target) so key derivation stays cheap enough for fuzzing — an unclamped `Arbitrary` value could request billions of iterations and blow the per-target time budget.

The CI action discovers targets via `cargo fuzz list`, so no workflow change is needed.

## Testing

Built and ran all three targets in WSL (nightly + cargo-fuzz 0.13.1), no crashes:

- `kdf_encrypted_data_deserialization` — 18.6M runs
- `derivation_parameters_deserialization` — 19.4M runs
- `decrypt_with_password` — full KDF round-trip, no timeout
