### PR TITLE
ci: publish the devolutions-crypto crate explicitly

### DIFF
--- a/.github/workflows/release-others.yml
+++ b/.github/workflows/release-others.yml
@@ -119,9 +119,9 @@ jobs:
       working-directory: ./rust-release
       run: |
         if [ '${{ inputs.publish_dry_run }}' == 'true' ]; then
-          cargo publish --dry-run
+          cargo publish -p devolutions-crypto --dry-run
         else
-          cargo publish
+          cargo publish -p devolutions-crypto
 
           git tag "rust-v${{ steps.version.outputs.version_native }}"
           git push origin "rust-v${{ steps.version.outputs.version_native }}"


### PR DESCRIPTION
cargo publish attempts to publish devolutions-crypto-python. The publish step fails with "Trusted Publishing tokens do not support creating new crates. Publish the crate manually, first". This crate does not need to be published.